### PR TITLE
Adding mutation fields and timeout for continous mutations

### DIFF
--- a/src/main/java/couchbase/test/docgen/DocumentGenerator.java
+++ b/src/main/java/couchbase/test/docgen/DocumentGenerator.java
@@ -5,7 +5,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
-
+import java.util.concurrent.TimeUnit;
 import couchbase.test.key.CircularKey;
 import couchbase.test.key.RandomKey;
 import couchbase.test.key.RandomSizeKey;
@@ -30,6 +30,7 @@ abstract class KVGenerator{
     private Class<?> valInstance;
     protected Method keyMethod;
     protected Method valMethod;
+    long startTime = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
 
     public KVGenerator(WorkLoadSettings ws, String keyClass, String valClass) throws ClassNotFoundException {
         super();
@@ -97,8 +98,9 @@ abstract class KVGenerator{
     public boolean has_next_update() {
         if (this.ws.dr.updateItr.get() < this.ws.dr.update_e)
             return true;
-        if (this.keyInstance.getSimpleName() == CircularKey.class.getSimpleName()) {
+        if (this.keyInstance.getSimpleName() == CircularKey.class.getSimpleName() || TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis())-startTime<ws.mutation_timeout) {
             this.resetUpdate();
+            this.ws.mutated+=1;
             return true;
         }
         return false;

--- a/src/main/java/couchbase/test/docgen/WorkLoadSettings.java
+++ b/src/main/java/couchbase/test/docgen/WorkLoadSettings.java
@@ -34,6 +34,9 @@ public class WorkLoadSettings extends WorkLoadBase {
     public boolean validate;
     public int mutated;
 
+    public String mutate_field;
+    public int mutation_timeout;
+
     public DocRange dr;
     public DocumentGenerator doc_gen;
 
@@ -43,15 +46,15 @@ public class WorkLoadSettings extends WorkLoadBase {
     public Boolean rollback_transaction;
     public boolean elastic;
     public String model;
-	public boolean mockVector;
-	public int dim;
+    public boolean mockVector;
+    public int dim;
 
     /**** Constructors ****/
     public WorkLoadSettings(String keyPrefix,
-            int keySize, int docSize, int c, int r, int u, int d, int e,
-            int workers, int ops, String loadType,
-            String keyType, String valueType,
-            boolean validate, boolean gtm, boolean deleted, int mutated) {
+                            int keySize, int docSize, int c, int r, int u, int d, int e,
+                            int workers, int ops, String loadType,
+                            String keyType, String valueType,
+                            boolean validate, boolean gtm, boolean deleted, int mutated) {
         super();
         this.keyPrefix = keyPrefix;
         this.keySize = keySize;
@@ -72,13 +75,13 @@ public class WorkLoadSettings extends WorkLoadBase {
         this.valueType = valueType;
         this.keyType = keyType;
     };
-    
+
     public WorkLoadSettings(String keyPrefix,
-            int keySize, int docSize, int c, int r, int u, int d, int e,
-            int workers, int ops, String loadType,
-            String keyType, String valueType,
-            boolean validate, boolean gtm, boolean deleted, int mutated,
-            boolean elastic, String model, boolean mockVector, int dim) {
+                            int keySize, int docSize, int c, int r, int u, int d, int e,
+                            int workers, int ops, String loadType,
+                            String keyType, String valueType,
+                            boolean validate, boolean gtm, boolean deleted, int mutated,
+                            boolean elastic, String model, boolean mockVector, int dim, String mutate_field, Integer mutation_timeout) {
         super();
         this.keyPrefix = keyPrefix;
         this.keySize = keySize;
@@ -90,7 +93,6 @@ public class WorkLoadSettings extends WorkLoadBase {
         this.expiry = e;
         this.workers = workers;
         this.ops = ops;
-
         this.batchSize = this.ops/this.workers;
         this.gtm = gtm;
         this.expectDeleted = deleted;
@@ -102,6 +104,8 @@ public class WorkLoadSettings extends WorkLoadBase {
         this.model = model;
         this.mockVector = mockVector;
         this.dim = dim;
+        this.mutate_field = mutate_field;
+        this.mutation_timeout = mutation_timeout;
     };
 
     public WorkLoadSettings(
@@ -125,8 +129,8 @@ public class WorkLoadSettings extends WorkLoadBase {
         this.dr = new DocRange(hm);
 
         // Populates this.transaction_pattern
-        this.create_transaction_load_pattern_per_worker(
-            key_range.getT1(), key_range.getT2(), transaction_pattern);
+            this.create_transaction_load_pattern_per_worker(
+                 key_range.getT1(), key_range.getT2(), transaction_pattern);
 
         // Create DocumentGenerator object
         this.doc_gen = new DocumentGenerator(this, this.keyType, this.valueType);

--- a/src/main/java/couchbase/test/sdk/Loader.java
+++ b/src/main/java/couchbase/test/sdk/Loader.java
@@ -160,7 +160,7 @@ public class Loader {
 
         Option esPwd = new Option("esPwd", "elastic", true, "ElasticSearch password");
         options.addOption(esPwd);
-        
+
         Option esAPIKey = new Option("esAPIKey", "elastic", true, "ElasticSearch APIKey");
         options.addOption(esAPIKey);
 
@@ -181,6 +181,12 @@ public class Loader {
 
         Option mutate = new Option("mutate", true, "mutate");
         options.addOption(mutate);
+
+        Option mutate_field = new Option("mutate_field", true, "Fields to be mutated");
+        options.addOption(mutate_field);
+
+        Option mutation_timeout = new Option("mutation_timeout", true, "");
+        options.addOption(mutation_timeout);
 
         Option maxTTL = new Option("maxTTL", true, "Expiry Time");
         options.addOption(maxTTL);
@@ -222,7 +228,9 @@ public class Loader {
                 Boolean.parseBoolean(cmd.getOptionValue("elastic", "false")),
                 cmd.getOptionValue("model", "sentence-transformers/paraphrase-MiniLM-L3-v2"),
                 Boolean.parseBoolean(cmd.getOptionValue("mockVector", "false")),
-                Integer.parseInt(cmd.getOptionValue("dim", "0")));
+                Integer.parseInt(cmd.getOptionValue("dim", "0")),
+                cmd.getOptionValue("mutate_field",""),
+                Integer.parseInt(cmd.getOptionValue("mutation_timeout","0")));
 
         HashMap<String, Number> dr = new HashMap<String, Number>();
         dr.put(DRConstants.create_s, Long.parseLong(cmd.getOptionValue(DRConstants.create_s, "0")));
@@ -282,7 +290,6 @@ public class Loader {
         tm.shutdown();
         client.disconnectCluster();
         client.shutdownEnv();
-        
         if (ws.elastic) {
             try {
                 esClient.restClient.close();

--- a/src/main/java/couchbase/test/val/Hotel.java
+++ b/src/main/java/couchbase/test/val/Hotel.java
@@ -25,11 +25,18 @@ public class Hotel {
     private ArrayList<String> names = new ArrayList<String>();
     private ArrayList<String> url = new ArrayList<String>();
     private ArrayList<ArrayList<JsonObject>> reviews = new ArrayList<ArrayList<JsonObject>>();
-    private int mutate = 0;
+    private int mutate;
+    private String mutate_field;
+    private Integer mutation_timeout;
+    private List<String> mutate_field_list = new ArrayList<>();
+
+    public WorkLoadSettings ws;
+
+
 
     public Hotel(WorkLoadSettings ws) {
         super();
-        this.mutate = ws.mutated;
+        this.ws = ws;
         this.random = new Random();
         this.random.setSeed(ws.keyPrefix.hashCode());
         faker = new Faker(random);
@@ -73,33 +80,64 @@ public class Hotel {
         }
         this.reviews.add(temp);
     }
-
     public JsonObject next(String key) {
         this.random = new Random();
         JsonObject jsonObject = JsonObject.create();
-        this.random.setSeed(key.hashCode());
-        int index = this.random.nextInt(4096);
-        ArrayList<JsonObject> review = this.reviews.get(index);
-        if(this.mutate != 0) {
-            this.random.setSeed((key+Integer.toString(this.mutate)).hashCode());
-            index = this.random.nextInt(4096);
+        this.random.setSeed((key).hashCode());
+        if(this.ws.mutated > 0){
+            this.random.setSeed((key+Integer.toString(this.ws.mutated)).hashCode());
         }
-        jsonObject.put("address", this.addresses.get(index));
-        jsonObject.put("city", this.city.get(index));
-        jsonObject.put("country", this.country.get(index));
-        jsonObject.put("email", this.emails.get(index));
+        int index = this.random.nextInt(4096);
         jsonObject.put("free_breakfast", this.random.nextBoolean());
         jsonObject.put("free_parking", this.random.nextBoolean());
         jsonObject.put("phone", faker.phoneNumber().phoneNumber());
         jsonObject.put("name", this.names.get(index));
         jsonObject.put("price", 500 + this.random.nextInt(1500));
         jsonObject.put("avg_rating", this.random.nextFloat()*5);
+        jsonObject.put("address", this.addresses.get(index));
+        jsonObject.put("city", this.city.get(index));
+        jsonObject.put("country", this.country.get(index));
+        jsonObject.put("email", this.emails.get(index));
+        jsonObject.put("name", this.names.get(index));
         jsonObject.put("public_likes", this.likes.get(index));
-        jsonObject.put("reviews", review);
+        jsonObject.put("reviews", this.reviews.get(index));
         jsonObject.put("type", this.htypes.get(index % htypes.size()));
         jsonObject.put("url", this.url.get(index));
         jsonObject.put("mutate", this.mutate);
+        if(this.ws.mutated > 0 && !this.ws.mutate_field.isEmpty()){
+            this.random.setSeed((key).hashCode());
+            index = this.random.nextInt(4096);
+            mutate_field_list = Arrays.asList(this.ws.mutate_field.split(","));
+            if(!mutate_field_list.contains("address"))
+                jsonObject.put("address", this.addresses.get(index));
+            if(!mutate_field_list.contains("city"))
+                jsonObject.put("city", this.city.get(index));
+            if(!mutate_field_list.contains("country"))
+                jsonObject.put("country", this.country.get(index));
+            if(!mutate_field_list.contains("email"))
+                jsonObject.put("email", this.emails.get(index));
+            if(!mutate_field_list.contains("name"))
+                jsonObject.put("name", this.names.get(index));
+            if(!mutate_field_list.contains("public_likes"))
+                jsonObject.put("public_likes", this.likes.get(index));
+            if(!mutate_field_list.contains("reviews"))
+                jsonObject.put("reviews", this.reviews.get(index));
+            if(!mutate_field_list.contains("type"))
+                jsonObject.put("type", this.htypes.get(index % htypes.size()));
+            if(!mutate_field_list.contains("url"))
+                jsonObject.put("url", this.url.get(index));
+            if(!mutate_field_list.contains("free_breakfast"))
+                jsonObject.put("free_breakfast", this.random.nextBoolean());
+            if(!mutate_field_list.contains("free_parking"))
+                jsonObject.put("free_parking", this.random.nextBoolean());
+            if(!mutate_field_list.contains("phone"))
+                jsonObject.put("phone", faker.phoneNumber().phoneNumber());
+            if(!mutate_field_list.contains("price"))
+                jsonObject.put("price", 500 + this.random.nextInt(1500));
+            if(!mutate_field_list.contains("avg_rating"))
+                jsonObject.put("avg_rating", this.random.nextFloat()*5);
+        }
+        jsonObject.put("mutate", this.ws.mutated);
         return jsonObject;
     }
-
 }


### PR DESCRIPTION
Change-Id: I14345f7bddd6baa9195fd0004078b8138c06d948
Added changes to the existing doc loader wherein continuous mutations can be run on all the fields or specific fields for the Hotel dataset for a given timeout.