### PR TITLE
Setting result=true in WorkLoadGenerate::run()

### DIFF
--- a/src/main/java/couchbase/test/loadgen/WorkLoadGenerate.java
+++ b/src/main/java/couchbase/test/loadgen/WorkLoadGenerate.java
@@ -109,6 +109,7 @@ public class WorkLoadGenerate extends Task{
 
     @Override
     public void run() {
+        this.result = true;
         logger.info("Starting " + this.taskName);
         // Set timeout in WorkLoadSettings
         this.dg.ws.setTimeoutDuration(60, "seconds");


### PR DESCRIPTION
Buy default this was set to false in Task(super class), so by setting this to true in run() and toggle to false only in case of real errors during load step