### PR TITLE
Fix effective worker count collapsing to 1 when ops_rate >> totalDocs…

### DIFF
--- a/src/main/java/RestServer/TaskRequest.java
+++ b/src/main/java/RestServer/TaskRequest.java
@@ -733,6 +733,12 @@ public class TaskRequest {
         int effectiveWorkers = Math.min(ws.workers,
             (int)((totalDocsToProcess + docsPerWorker - 1) / docsPerWorker));  // ceil division
 
+        // When ops_rate >> totalDocsToProcess, the ceil division above collapses to 1 even if
+        // multiple workers were requested. Ensure we use at least min(ws.workers, totalDocsToProcess)
+        // workers so concurrency-dependent tests (e.g. dedupe-disable) are not silently serialized.
+        int minWorkers = (int) Math.min(ws.workers, totalDocsToProcess);
+        effectiveWorkers = Math.max(effectiveWorkers, minWorkers);
+
         System.out.println("Smart worker counting: Total docs=" + totalDocsToProcess +
                           ", Docs per worker=" + docsPerWorker +
                           ", Requested workers=" + ws.workers +


### PR DESCRIPTION
…ToProcess

- High ops values inflate docsPerWorker via batchSize=(ops/workers)*percent/100
- ceil(totalDocs/docsPerWorker) then produces 1 even when multiple workers requested
- Add floor of min(ws.workers, totalDocsToProcess) to preserve requested concurrency
- Avoids silently serializing tests that depend on multiple threads (e.g. dedupe-disable)
- Still caps workers at totalDocsToProcess to prevent truly idle threads (b1f5d24 preserved)