### PR TITLE
Add diagnostic logging to trace doc count mismatch

### DIFF
--- a/src/main/java/RestServer/TaskRequest.java
+++ b/src/main/java/RestServer/TaskRequest.java
@@ -752,6 +752,14 @@ public class TaskRequest {
                           ", Requested workers=" + ws.workers +
                           ", Effective workers=" + effectiveWorkers);
 
+        System.out.println("[DOC_LOAD] bucket=" + this.bucketName
+                + " scope=" + this.scopeName
+                + " collection=" + this.collectionName
+                + " create=[" + this.createStartIndex + "," + this.createEndIndex + ")"
+                + " total_docs=" + totalDocsToProcess
+                + " effective_workers=" + effectiveWorkers
+                + " task=" + task_name);
+
         // Only spawn effective workers
         for (int i = 0; i < effectiveWorkers; i++) {
             String th_name = task_name + "_" + i;

--- a/src/main/java/couchbase/loadgen/WorkLoadGenerate.java
+++ b/src/main/java/couchbase/loadgen/WorkLoadGenerate.java
@@ -234,6 +234,7 @@ public class WorkLoadGenerate extends Task{
         }
 
         int ops = 0;
+        long createDocsWritten = 0;
         boolean flag = false;
         Instant trackFailureTime_start = Instant.now();
         while(! this.stop_load) {
@@ -258,9 +259,16 @@ public class WorkLoadGenerate extends Task{
                     List<Result> result = new ArrayList<Result>();
                     if(this.sdk != null)
                         result = docops.bulkInsert(this.sdk.connection, docs, setOptions);
+                    createDocsWritten += docs.size();
                     ops += dg.ws.batchSize*dg.ws.creates/100;
                     if(this.trackFailures && result.size()>0){
                         this.result = false;
+                        logger.warn("[CREATE_FAIL] task=" + this.taskName
+                                + " collection=" + this.collection
+                                + " batch_sent=" + docs.size()
+                                + " failed=" + result.size()
+                                + " first_failed_key=" + result.get(0).id()
+                                + " error=" + result.get(0).err().getClass().getSimpleName());
                         try {
                             failedMutations.get("create").addAll(result);
                         } catch (Exception e) {
@@ -421,54 +429,86 @@ public class WorkLoadGenerate extends Task{
             }
         }
         logger.info(this.taskName + " is completed!");
+        long retryDocsInserted = 0;
         if (retryTimes > 0 && failedMutations.size() > 0) {
+            for (Entry<String, List<Result>> optype: failedMutations.entrySet()) {
+                logger.warn("[RETRY_START] task=" + this.taskName
+                        + " collection=" + this.collection
+                        + " op=" + optype.getKey()
+                        + " count=" + optype.getValue().size());
+            }
             this.result = true;
             for (Entry<String, List<Result>> optype: failedMutations.entrySet()) {
                 for (Result r: optype.getValue()) {
-                    System.out.println("Loader Retrying: " + r.id() + " -> " + r.err().getClass().getSimpleName());
+                    logger.warn("[RETRY_ATTEMPT] task=" + this.taskName
+                            + " op=" + optype.getKey()
+                            + " key=" + r.id()
+                            + " original_error=" + r.err().getClass().getSimpleName());
                     switch(optype.getKey()) {
                     case "create":
                         try {
                             docops.insert(r.id(), r.document(), this.sdk.connection, setOptions);
                             failedMutations.get(optype.getKey()).remove(r);
+                            retryDocsInserted++;
+                            logger.info("[RETRY_SUCCESS] op=create key=" + r.id());
                         } catch (TimeoutException|ServerOutOfMemoryException e) {
-                            System.out.println("Retry Create failed for key: " + r.id());
+                            logger.error("[RETRY_FAIL] op=create key=" + r.id() + " error=" + e.getClass().getSimpleName());
                             this.result = false;
                         } catch (DocumentExistsException e) {
-                            System.out.println("Retry Create failed for key: " + r.id());
+                            // Doc already in bucket from original attempt — not an extra doc
+                            logger.warn("[RETRY_EXISTS] op=create key=" + r.id() + " — doc already exists, original write succeeded");
                         } catch (Exception e) {
-                            System.out.println("Exception during create'" + r.id() + "' :: " + e.toString());
+                            logger.error("[RETRY_FAIL] op=create key=" + r.id() + " error=" + e.toString());
                             this.result = false;
                         }
+                        // WARNING: missing break — falls through to 'update' case below
+                        logger.warn("[RETRY_FALLTHROUGH] op=create falling through to update for key=" + r.id()
+                                + " — this is a switch bug; create will also be upserted");
                     case "update":
                         try {
                             docops.upsert(r.id(), r.document(), this.sdk.connection, upsertOptions);
                             failedMutations.get(optype.getKey()).remove(r);
+                            logger.info("[RETRY_SUCCESS] op=update key=" + r.id());
                         } catch (TimeoutException|ServerOutOfMemoryException e) {
-                            System.out.println("Retry update failed for key: " + r.id());
+                            logger.error("[RETRY_FAIL] op=update key=" + r.id() + " error=" + e.getClass().getSimpleName());
                             this.result = false;
                         }  catch (DocumentExistsException e) {
-                            System.out.println("Retry update failed for key: " + r.id());
+                            logger.error("[RETRY_FAIL] op=update key=" + r.id() + " error=" + e.getClass().getSimpleName());
                             this.result = false;
                         } catch (Exception e) {
-                            System.out.println("Exception during update'" + r.id() + "' :: " + e.toString());
+                            logger.error("[RETRY_FAIL] op=update key=" + r.id() + " error=" + e.toString());
                             this.result = false;
                         }
+                        // WARNING: missing break — falls through to 'delete' case below
+                        logger.warn("[RETRY_FALLTHROUGH] op=update falling through to delete for key=" + r.id()
+                                + " — this is a switch bug; doc will also be deleted");
                     case "delete":
                         try {
                             docops.delete(r.id(), this.sdk.connection, removeOptions);
                             failedMutations.get(optype.getKey()).remove(r);
+                            logger.info("[RETRY_SUCCESS] op=delete key=" + r.id());
                         } catch (TimeoutException|ServerOutOfMemoryException e) {
-                            System.out.println("Retry delete failed for key: " + r.id());
+                            logger.error("[RETRY_FAIL] op=delete key=" + r.id() + " error=" + e.getClass().getSimpleName());
                             this.result = false;
                         } catch (DocumentNotFoundException e) {
-                            System.out.println("Retry delete failed for key: " + r.id());
+                            logger.error("[RETRY_FAIL] op=delete key=" + r.id() + " error=DocumentNotFoundException");
                             this.result = false;
                         }
                     }
                 }
             }
         }
+        logger.info("[LOAD_COMPLETE] task=" + this.taskName
+                + " bucket=" + this.bucket_name
+                + " scope=" + this.scope
+                + " collection=" + this.collection
+                + " create_docs_written=" + createDocsWritten
+                + " retry_docs_inserted=" + retryDocsInserted
+                + " total=" + (createDocsWritten + retryDocsInserted)
+                + " final_createItr=" + this.dg.ws.dr.createItr.get()
+                + " create_s=" + this.dg.ws.dr.create_s
+                + " create_e=" + this.dg.ws.dr.create_e
+                + " expected=" + (this.dg.ws.dr.create_e - this.dg.ws.dr.create_s));
     }
 
     @Override

--- a/src/main/java/couchbase/sdk/SDKClientPool.java
+++ b/src/main/java/couchbase/sdk/SDKClientPool.java
@@ -95,23 +95,30 @@ public class SDKClientPool {
         // Check if client is already cached for this collection
         ClientInfo existing = clientCache.get(cache_key);
         if (existing != null) {
-            existing.counter.incrementAndGet();
+            int cnt = existing.counter.incrementAndGet();
+            logger.debug("[POOL_HIT] cache_key=" + cache_key + " counter=" + cnt);
             return existing.client;
         }
 
         // Get idle client pool for this bucket
         LinkedBlockingQueue<SDKClient> idlePool = idleClients.get(bucket_name);
         if (idlePool == null) {
+            logger.warn("[POOL_MISS] No idle pool found for bucket=" + bucket_name);
             return null;
         }
+
+        logger.info("[POOL_MISS] cache_key=" + cache_key
+                + " idle=" + idlePool.size()
+                + " busy=" + busyClients.getOrDefault(bucket_name, new LinkedBlockingQueue<>()).size());
 
         // Block until a client becomes available or timeout expires.
         // With 200-300 threads sharing a finite pool, spinning with a fixed retry cap
         // causes spurious failures on long-running loads — blocking here is cheaper and correct.
         SDKClient client = idlePool.poll(CLIENT_WAIT_TIMEOUT_MINUTES, TimeUnit.MINUTES);
         if (client == null) {
-            logger.error("Timed out waiting " + CLIENT_WAIT_TIMEOUT_MINUTES
-                    + " min for idle SDK client for bucket " + bucket_name);
+            logger.error("[POOL_TIMEOUT] Timed out waiting " + CLIENT_WAIT_TIMEOUT_MINUTES
+                    + " min for idle SDK client for bucket=" + bucket_name
+                    + " busy=" + busyClients.getOrDefault(bucket_name, new LinkedBlockingQueue<>()).size());
             return null;
         }
 
@@ -123,6 +130,10 @@ public class SDKClientPool {
 
         // Cache client reference with thread-safe counter
         clientCache.put(cache_key, new ClientInfo(client, new AtomicInteger(1)));
+
+        logger.info("[POOL_ASSIGN] cache_key=" + cache_key
+                + " idle=" + idlePool.size()
+                + " busy=" + busyClients.get(bucket_name).size());
 
         return client;
     }
@@ -138,25 +149,32 @@ public class SDKClientPool {
         // Get cached client info
         ClientInfo info = clientCache.get(cache_key);
         if (info == null) {
+            // TOCTOU: second thread's put overwrote first; this client is now orphaned in busyClients
+            logger.warn("[POOL_ORPHAN] release_client called but no cache entry for cache_key=" + cache_key
+                    + " — client is orphaned (likely TOCTOU race); pool capacity reduced by 1");
             return;
         }
 
         // Decrement counter atomically
         int newCount = info.counter.decrementAndGet();
+        logger.debug("[POOL_RELEASE] cache_key=" + cache_key + " counter=" + newCount);
 
         if (newCount == 0) {
             // Remove from cache atomically
             clientCache.remove(cache_key);
-            
+
             // Remove from busy pool and add to idle pool atomically
             LinkedBlockingQueue<SDKClient> busyPool = busyClients.get(bucket_key);
             LinkedBlockingQueue<SDKClient> idlePool = idleClients.get(bucket_key);
-            
+
             if (busyPool != null) {
                 busyPool.remove(client);
             }
             if (idlePool != null) {
                 idlePool.add(client);
+                logger.info("[POOL_RETURN] cache_key=" + cache_key
+                        + " idle=" + idlePool.size()
+                        + " busy=" + (busyPool != null ? busyPool.size() : 0));
             }
         }
     }

--- a/src/main/java/utils/docgen/DocumentGenerator.java
+++ b/src/main/java/utils/docgen/DocumentGenerator.java
@@ -472,7 +472,12 @@ public class DocumentGenerator extends KVGenerator{
         int count = 0;
         while (count < ws.batchSize * ws.creates / 100) {
             long idx = this.ws.dr.createItr.getAndIncrement();
-            if (idx >= this.ws.dr.create_e) break;
+            if (idx >= this.ws.dr.create_e) {
+                System.out.println("[BATCH_DONE] thread=" + Thread.currentThread().getName()
+                        + " claimed_idx=" + idx + " create_e=" + this.ws.dr.create_e
+                        + " docs_in_batch=" + count);
+                break;
+            }
             docs.add(nextCreateAt(idx));
             count += 1;
         }

--- a/src/main/java/utils/docgen/DocumentGenerator.java
+++ b/src/main/java/utils/docgen/DocumentGenerator.java
@@ -214,13 +214,17 @@ abstract class KVGenerator{
         if (this.ws.dr.readItr.get() < this.ws.dr.read_e)
             return true;
         if (this.keyInstance.getSimpleName().equals(CircularKey.class.getSimpleName())) {
-            try {
-                if ((boolean)this.iterationsMethod.invoke(this.keys)) {
-                    this.resetRead();
+            synchronized (this.keys) {
+                if (this.ws.dr.readItr.get() < this.ws.dr.read_e)
                     return true;
+                try {
+                    if ((boolean)this.iterationsMethod.invoke(this.keys)) {
+                        this.resetRead();
+                        return true;
+                    }
+                } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e1) {
+                    e1.printStackTrace();
                 }
-            } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e1) {
-                e1.printStackTrace();
             }
         }
         return false;
@@ -230,14 +234,18 @@ abstract class KVGenerator{
         if (this.ws.dr.updateItr.get() < this.ws.dr.update_e)
             return true;
         if (this.keyInstance.getSimpleName().equals(CircularKey.class.getSimpleName())) {
-            try {
-                if ((boolean)this.iterationsMethod.invoke(this.keys)) {
-                    this.resetUpdate();
-                    this.ws.mutated += 1;
+            synchronized (this.keys) {
+                if (this.ws.dr.updateItr.get() < this.ws.dr.update_e)
                     return true;
+                try {
+                    if ((boolean)this.iterationsMethod.invoke(this.keys)) {
+                        this.resetUpdate();
+                        this.ws.mutated += 1;
+                        return true;
+                    }
+                } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e1) {
+                    e1.printStackTrace();
                 }
-            } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e1) {
-                e1.printStackTrace();
             }
         }
         if (TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis())-startTime<ws.mutation_timeout) {
@@ -252,13 +260,17 @@ abstract class KVGenerator{
         if (this.ws.dr.expiryItr.get() < this.ws.dr.expiry_e)
             return true;
         if (this.keyInstance.getSimpleName().equals(CircularKey.class.getSimpleName())) {
-            try {
-                if ((boolean)this.iterationsMethod.invoke(this.keys, null)) {
-                    this.resetExpiry();
+            synchronized (this.keys) {
+                if (this.ws.dr.expiryItr.get() < this.ws.dr.expiry_e)
                     return true;
+                try {
+                    if ((boolean)this.iterationsMethod.invoke(this.keys, null)) {
+                        this.resetExpiry();
+                        return true;
+                    }
+                } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e1) {
+                    e1.printStackTrace();
                 }
-            } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e1) {
-                e1.printStackTrace();
             }
         }
         return false;


### PR DESCRIPTION
- [DOC_LOAD] in TaskRequest: exact create=[start,end) range per task
- [LOAD_COMPLETE] in WorkLoadGenerate: actual docs written per worker, retry_docs_inserted, final createItr vs create_e and expected count
- [CREATE_FAIL] in WorkLoadGenerate: logs failed inserts with key and error
- [RETRY_START/ATTEMPT/SUCCESS/FAIL/EXISTS] in retry block: full retry visibility including DocumentExistsException (silent success) detection
- [RETRY_FALLTHROUGH] WARN: exposes switch fall-through bug where create retries also trigger upsert then delete
- [BATCH_DONE] in DocumentGenerator: logs when worker hits create_e boundary
- [POOL_HIT/MISS/ASSIGN/ORPHAN/RELEASE/RETURN] in SDKClientPool: full client lifecycle including TOCTOU orphan detection