### PR TITLE
Fix race condition on CircularKey iterations in multi-worker loads

### DIFF
--- a/src/main/java/utils/docgen/DocumentGenerator.java
+++ b/src/main/java/utils/docgen/DocumentGenerator.java
@@ -220,13 +220,17 @@ abstract class KVGenerator{
         if (this.ws.dr.readItr.get() < this.ws.dr.read_e)
             return true;
         if (this.keyInstance.getSimpleName().equals(CircularKey.class.getSimpleName())) {
-            try {
-                if ((boolean)this.iterationsMethod.invoke(this.keys)) {
-                    this.resetRead();
+            synchronized (this.keys) {
+                if (this.ws.dr.readItr.get() < this.ws.dr.read_e)
                     return true;
+                try {
+                    if ((boolean)this.iterationsMethod.invoke(this.keys)) {
+                        this.resetRead();
+                        return true;
+                    }
+                } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e1) {
+                    e1.printStackTrace();
                 }
-            } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e1) {
-                e1.printStackTrace();
             }
         }
         return false;
@@ -236,14 +240,18 @@ abstract class KVGenerator{
         if (this.ws.dr.updateItr.get() < this.ws.dr.update_e)
             return true;
         if (this.keyInstance.getSimpleName().equals(CircularKey.class.getSimpleName())) {
-            try {
-                if ((boolean)this.iterationsMethod.invoke(this.keys)) {
-                    this.resetUpdate();
-                    this.ws.mutated += 1;
+            synchronized (this.keys) {
+                if (this.ws.dr.updateItr.get() < this.ws.dr.update_e)
                     return true;
+                try {
+                    if ((boolean)this.iterationsMethod.invoke(this.keys)) {
+                        this.resetUpdate();
+                        this.ws.mutated += 1;
+                        return true;
+                    }
+                } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e1) {
+                    e1.printStackTrace();
                 }
-            } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e1) {
-                e1.printStackTrace();
             }
         }
         if (TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis())-startTime<ws.mutation_timeout) {
@@ -258,13 +266,17 @@ abstract class KVGenerator{
         if (this.ws.dr.expiryItr.get() < this.ws.dr.expiry_e)
             return true;
         if (this.keyInstance.getSimpleName().equals(CircularKey.class.getSimpleName())) {
-            try {
-                if ((boolean)this.iterationsMethod.invoke(this.keys, null)) {
-                    this.resetExpiry();
+            synchronized (this.keys) {
+                if (this.ws.dr.expiryItr.get() < this.ws.dr.expiry_e)
                     return true;
+                try {
+                    if ((boolean)this.iterationsMethod.invoke(this.keys, null)) {
+                        this.resetExpiry();
+                        return true;
+                    }
+                } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e1) {
+                    e1.printStackTrace();
                 }
-            } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e1) {
-                e1.printStackTrace();
             }
         }
         return false;


### PR DESCRIPTION
- Multiple workers sharing one DocumentGenerator all call checkIterations() simultaneously when a pass completes
- CircularKey.iterations is a plain int — concurrent decrements cause lost updates, fewer passes than expected, and wrong mutation counts (e.g. 12193 instead of 20000)
- Wrap the pass-completion path in has_next_update(), has_next_read(), and has_next_expiry() with synchronized(this.keys)
- Double-check the iterator inside the lock: first thread resets it to 0, all following threads see it reset and skip decrement
- Concurrent doc generation and bulkUpsert are unaffected — workers still run in parallel during each pass