### PR TITLE
Read sparse vectors from a binary sidecar to load 2.9x faster

### DIFF
--- a/src/main/java/utils/val/MSMARCOEmbeddingProduct.java
+++ b/src/main/java/utils/val/MSMARCOEmbeddingProduct.java
@@ -63,9 +63,14 @@ public class MSMARCOEmbeddingProduct implements Closeable {
 
         try {
             this.store = SparseVectorStore.openIfPresent(sourcePath);
-            if (store == null)
+            if (store == null) {
+                // Both belong to the text path only. Opening them anyway when the sidecar
+                // is in use would leave every generator holding a descriptor it never
+                // reads, on top of the sidecar's own -- and nothing in the repo closes a
+                // generator while ulimit -n is 1024 on the volume hosts. See offsetOf().
                 this.idxFilePath = ensureIndex(sourcePath);
-            this.fileChannel = FileChannel.open(Paths.get(sourcePath), StandardOpenOption.READ);
+                this.fileChannel = FileChannel.open(Paths.get(sourcePath), StandardOpenOption.READ);
+            }
 
             if (ws.creates > 0 && ws.dr != null) {
                 initRangeBounds(ws.dr.create_s);

--- a/src/main/java/utils/val/MSMARCOEmbeddingProduct.java
+++ b/src/main/java/utils/val/MSMARCOEmbeddingProduct.java
@@ -1,20 +1,9 @@
 package utils.val;
 
-import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.channels.Channels;
-import java.nio.channels.FileChannel;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
-import java.nio.file.StandardOpenOption;
-import java.util.Arrays;
 import java.util.Base64;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -23,7 +12,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import utils.docgen.WorkLoadSettings;
 
 public class MSMARCOEmbeddingProduct implements Closeable {
-    private static final int STREAM_BUFFER_SIZE = 1024 * 1024;
 
     // 3 step ranges for 8,841,823 vectors
     private static final long[] STEPS = new long[] {
@@ -33,15 +21,10 @@ public class MSMARCOEmbeddingProduct implements Closeable {
     public WorkLoadSettings ws;
     private final String sourcePath;
 
-    // <vecFilePath>.idx holds one little-endian long per line: the byte offset of
-    // that line in the .vec file. It is read one entry at a time via a positional
-    // read rather than slurped into a long[] — for an 8.8M-line source that array
-    // is ~70MB, and every generator instance would hold its own private copy.
-    // Path only, not an open channel: see offsetOf().
-    private String idxFilePath;
-
-    private FileChannel fileChannel;
-    private BufferedReader lineReader;
+    // Records come from a binary sidecar built once from the .vec source. Reading
+    // primitives back costs no text parsing, which is what previously dominated this
+    // loader's allocation; see SparseVectorStore for the detail.
+    private SparseVectorStore store;
 
     private long rangeStart;
     private long rangeEnd;
@@ -56,128 +39,27 @@ public class MSMARCOEmbeddingProduct implements Closeable {
         this.sourcePath = resolveSourcePath(ws);
 
         try {
-            this.idxFilePath = ensureIndex(sourcePath);
-            this.fileChannel = FileChannel.open(Paths.get(sourcePath), StandardOpenOption.READ);
+            this.store = SparseVectorStore.open(sourcePath);
 
             if (ws.creates > 0 && ws.dr != null) {
                 initRangeBounds(ws.dr.create_s);
                 this.workerStartRecord = ws.dr.create_s;
                 this.isMutation = false;
-                seekToRecord(ws.dr.create_s);
+                this.currentRecord = ws.dr.create_s;
             } else if (ws.updates > 0 && ws.dr != null) {
                 initRangeBounds(ws.dr.update_s);
                 this.workerStartRecord = ws.dr.update_s;
                 this.isMutation = true;
-                seekToRecord(rangeStart + ((workerStartRecord - rangeStart + ws.mutated) % rangeSize));
+                this.currentRecord = rangeStart + ((workerStartRecord - rangeStart + ws.mutated) % rangeSize);
             } else if (ws.expiry > 0 && ws.dr != null) {
                 initRangeBounds(ws.dr.expiry_s);
                 this.workerStartRecord = ws.dr.expiry_s;
                 this.isMutation = true;
-                seekToRecord(ws.dr.expiry_s);
+                this.currentRecord = ws.dr.expiry_s;
             }
         } catch (IOException e) {
-            throw new RuntimeException("Failed to initialize MSMARCO embedding stream: " + e.getMessage(), e);
+            throw new RuntimeException("Failed to initialize MSMARCO embedding source: " + e.getMessage(), e);
         }
-    }
-
-    // Ensures the .idx sidecar exists alongside the .vec file, building it if absent,
-    // and returns its path. Synchronized to prevent concurrent workers from racing to
-    // build the same index file.
-    private static synchronized String ensureIndex(String vecFilePath) throws IOException {
-        String idxFilePath = vecFilePath + ".idx";
-        if (!Files.exists(Paths.get(idxFilePath)))
-            buildAndSaveIndex(vecFilePath, idxFilePath);
-        return idxFilePath;
-    }
-
-    // Single pass: scans .vec for newlines, streams offsets directly to .idx.
-    // Never holds all offsets in memory.
-    private static void buildAndSaveIndex(String vecFilePath, String idxFilePath) throws IOException {
-        System.out.println("Building offset index for: " + vecFilePath + " -> " + idxFilePath);
-        ByteBuffer readBuf = ByteBuffer.allocateDirect(STREAM_BUFFER_SIZE);
-        ByteBuffer writeBuf = ByteBuffer.allocate(8 * 8192).order(ByteOrder.LITTLE_ENDIAN);
-        long bytePos = 0;
-
-        // Build into a temp file and rename atomically. ensureIndex()'s exists-check only
-        // serialises workers inside one JVM; writing in place lets a second process observe
-        // a file that exists but is still being written, and read truncated offsets.
-        Path tmp = Paths.get(idxFilePath + ".tmp");
-        try {
-        try (FileChannel vecCh = FileChannel.open(Paths.get(vecFilePath), StandardOpenOption.READ);
-             FileChannel idxCh = FileChannel.open(tmp,
-                     StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)) {
-
-            // Line 0 always starts at byte 0
-            writeBuf.putLong(0L);
-
-            while (vecCh.read(readBuf) > 0) {
-                readBuf.flip();
-                while (readBuf.hasRemaining()) {
-                    byte b = readBuf.get();
-                    bytePos++;
-                    if (b == '\n') {
-                        writeBuf.putLong(bytePos);
-                        if (!writeBuf.hasRemaining()) {
-                            writeBuf.flip();
-                            idxCh.write(writeBuf);
-                            writeBuf.clear();
-                        }
-                    }
-                }
-                readBuf.clear();
-            }
-            writeBuf.flip();
-            if (writeBuf.hasRemaining())
-                idxCh.write(writeBuf);
-            idxCh.force(true);
-        }
-        Files.move(tmp, Paths.get(idxFilePath),
-                StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
-        } catch (IOException e) {
-            Files.deleteIfExists(tmp);
-            throw e;
-        }
-
-        System.out.println("Index built: " + idxFilePath);
-    }
-
-    // Reads the byte offset of a single line from the .idx sidecar.
-    //
-    // The channel is opened per call rather than held for this object's lifetime. Nothing
-    // in the repo calls close() on a generator, and TaskRequest builds
-    // process_concurrency of them per request in a long-running server, so a retained
-    // channel accumulates for the JVM's lifetime -- and ulimit -n is 1024 on the volume
-    // hosts. Opening here keeps this class at the same descriptor count as before this
-    // change, where loadIndex() opened and closed the index inside try-with-resources.
-    //
-    // Not a hot path: seekToRecord() is the only caller, reached once per generator in
-    // create mode and once per iteration wrap in mutation mode, since keys arrive in
-    // ascending order and currentRecord already tracks the target.
-    private long offsetOf(long recordIndex) throws IOException {
-        ByteBuffer buf = ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN);
-        try (FileChannel idxChannel = FileChannel.open(Paths.get(idxFilePath), StandardOpenOption.READ)) {
-            long records = idxChannel.size() / 8;
-            if (recordIndex < 0 || recordIndex >= records)
-                throw new IOException("record index " + recordIndex + " out of bounds [0, " + records
-                        + ") in " + idxFilePath);
-            long pos = recordIndex * 8L;
-            while (buf.hasRemaining()) {
-                if (idxChannel.read(buf, pos + buf.position()) < 0)
-                    throw new IOException("truncated offset index at record " + recordIndex);
-            }
-        }
-        buf.flip();
-        return buf.getLong();
-    }
-
-    // O(1) seek to any record by direct byte offset lookup.
-    // Do NOT close lineReader — closing Channels.newInputStream would close fileChannel.
-    private void seekToRecord(long recordIndex) throws IOException {
-        fileChannel.position(offsetOf(recordIndex));
-        lineReader = new BufferedReader(
-                new InputStreamReader(Channels.newInputStream(fileChannel), StandardCharsets.UTF_8),
-                STREAM_BUFFER_SIZE);
-        currentRecord = recordIndex;
     }
 
     private void initRangeBounds(long docIndex) {
@@ -197,13 +79,10 @@ public class MSMARCOEmbeddingProduct implements Closeable {
         int id = keyNum + this.ws.mutated;
 
         if (isMutation) {
-            long targetRecord = rangeStart + ((keyNum - rangeStart + ws.mutated) % rangeSize);
-            if (targetRecord != currentRecord) {
-                seekToRecord(targetRecord);
-            }
+            currentRecord = rangeStart + ((keyNum - rangeStart + ws.mutated) % rangeSize);
         }
 
-        Object sparseEmbedding = readNextEmbedding();
+        Object sparseEmbedding = store.read(currentRecord);
         currentRecord++;
 
         // Metadata based on range boundaries
@@ -240,151 +119,6 @@ public class MSMARCOEmbeddingProduct implements Closeable {
         return new Product1(id, embedding, size, color, brand, country, category, type, review, ws.mutated);
     }
 
-    private Object readNextEmbedding() throws IOException {
-        if (lineReader == null) {
-            throw new IOException("Reader is null");
-        }
-        String line = lineReader.readLine();
-        if (line == null) {
-            throw new IOException("No more embedding records available from source: " + sourcePath);
-        }
-        while (isWhitespaceOnly(line)) {
-            line = lineReader.readLine();
-            if (line == null) {
-                throw new IOException("No more embedding records available from source: " + sourcePath);
-            }
-        }
-        return parseRecord(line);
-    }
-
-    // Parses one "<id>\t[indices]\t[values]" record into { int[], float[] }.
-    //
-    // The pair is kept as primitive arrays rather than List<Integer>/List<Float>: at
-    // ~300 non-zeros the boxed form costs ~12KB per document against ~2.5KB here, and
-    // every in-flight batch retains batchSize x workers of them.
-    //
-    // Returned as Object[] so Jackson still emits [[indices...],[values...]], byte for
-    // byte what the nested-List form produced.
-    private static Object parseRecord(String line) throws IOException {
-        int firstTab = line.indexOf('\t');
-        int secondTab = firstTab < 0 ? -1 : line.indexOf('\t', firstTab + 1);
-        if (secondTab < 0)
-            throw new IOException("Invalid .vec format: expected 3 tab-separated parts");
-
-        int indicesOpen = line.indexOf('[', firstTab + 1);
-        int indicesClose = line.lastIndexOf(']', secondTab);
-        int valuesOpen = line.indexOf('[', secondTab + 1);
-        int valuesClose = line.lastIndexOf(']');
-        if (indicesOpen < 0 || indicesClose < indicesOpen || valuesOpen < 0 || valuesClose < valuesOpen)
-            throw new IOException("Invalid .vec format: malformed index/value list");
-
-        int count = countElements(line, indicesOpen + 1, indicesClose);
-        int[] indices = new int[count];
-        float[] values = new float[count];
-        int indexCount = parseIndices(line, indicesOpen + 1, indicesClose, indices);
-        int valueCount = parseValues(line, valuesOpen + 1, valuesClose, values);
-        if (indexCount != valueCount) {
-            throw new IOException("Indices and values arrays have different lengths: "
-                    + indexCount + " vs " + valueCount);
-        }
-        // countElements() counts separators while the parsers skip runs of them, so an
-        // empty element -- a trailing or doubled comma -- makes count overshoot what is
-        // actually parsed. Trim to the parsed length: leaving the surplus slots at their
-        // defaults would inject a phantom index 0 / value 0.0 into the document, and the
-        // check above cannot catch it because both sides undercount identically. The
-        // split(",") this replaced dropped trailing empties, so trimming keeps that
-        // behaviour. Never taken on well-formed input.
-        if (indexCount != count) {
-            indices = Arrays.copyOf(indices, indexCount);
-            values = Arrays.copyOf(values, indexCount);
-        }
-        return new Object[] { indices, values };
-    }
-
-    // Counts comma-separated elements in [from, to); 0 if the region is whitespace only.
-    private static int countElements(String s, int from, int to) {
-        int i = from;
-        while (i < to && s.charAt(i) <= ' ')
-            i++;
-        if (i >= to)
-            return 0;
-        int count = 1;
-        for (; i < to; i++)
-            if (s.charAt(i) == ',')
-                count++;
-        return count;
-    }
-
-    // Parses the comma-separated integers in [from, to) into out. Allocation free.
-    private static int parseIndices(String s, int from, int to, int[] out) throws IOException {
-        int n = 0;
-        int i = from;
-        while (i < to) {
-            while (i < to && isSeparator(s.charAt(i)))
-                i++;
-            if (i >= to)
-                break;
-            boolean negative = s.charAt(i) == '-';
-            if (negative || s.charAt(i) == '+')
-                i++;
-            int start = i;
-            int value = 0;
-            while (i < to) {
-                char c = s.charAt(i);
-                if (c < '0' || c > '9')
-                    break;
-                value = value * 10 + (c - '0');
-                i++;
-            }
-            if (i == start)
-                throw new IOException("Invalid .vec format: malformed index at offset " + start);
-            if (n == out.length)
-                throw new IOException("Invalid .vec format: more indices than counted");
-            out[n++] = negative ? -value : value;
-        }
-        return n;
-    }
-
-    // Parses the comma-separated floats in [from, to) into out.
-    //
-    // Float.parseFloat is kept, on a per-token substring, rather than accumulating the
-    // decimal by hand: the source prints up to 17 significant digits, past the 2^53
-    // mantissa limit under which a hand-rolled accumulator is still provably correctly
-    // rounded. parseFloat is what guarantees the emitted JSON is unchanged.
-    private static int parseValues(String s, int from, int to, float[] out) throws IOException {
-        int n = 0;
-        int i = from;
-        while (i < to) {
-            while (i < to && isSeparator(s.charAt(i)))
-                i++;
-            if (i >= to)
-                break;
-            int start = i;
-            while (i < to && s.charAt(i) != ',')
-                i++;
-            int end = i;
-            while (end > start && s.charAt(end - 1) <= ' ')
-                end--;
-            if (end == start)
-                throw new IOException("Invalid .vec format: empty value at offset " + start);
-            if (n == out.length)
-                throw new IOException("Invalid .vec format: more values than indices");
-            out[n++] = Float.parseFloat(s.substring(start, end));
-        }
-        return n;
-    }
-
-    private static boolean isSeparator(char c) {
-        return c == ',' || c <= ' ';
-    }
-
-    private static boolean isWhitespaceOnly(String s) {
-        for (int i = 0; i < s.length(); i++)
-            if (s.charAt(i) > ' ')
-                return false;
-        return true;
-    }
-
     private static String encodeSparseToBase64(Object sparseEmbedding) {
         Object[] embedding = (Object[]) sparseEmbedding;
         int[] indices = (int[]) embedding[0];
@@ -414,11 +148,9 @@ public class MSMARCOEmbeddingProduct implements Closeable {
 
     @Override
     public void close() throws IOException {
-        // Do not close lineReader — closing Channels.newInputStream wraps would close fileChannel
-        lineReader = null;
-        if (fileChannel != null) {
-            fileChannel.close();
-            fileChannel = null;
+        if (store != null) {
+            store.close();
+            store = null;
         }
     }
 

--- a/src/main/java/utils/val/MSMARCOEmbeddingProduct.java
+++ b/src/main/java/utils/val/MSMARCOEmbeddingProduct.java
@@ -1,9 +1,20 @@
 package utils.val;
 
+import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
 import java.util.Base64;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -12,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import utils.docgen.WorkLoadSettings;
 
 public class MSMARCOEmbeddingProduct implements Closeable {
+    private static final int STREAM_BUFFER_SIZE = 1024 * 1024;
 
     // 3 step ranges for 8,841,823 vectors
     private static final long[] STEPS = new long[] {
@@ -21,10 +33,21 @@ public class MSMARCOEmbeddingProduct implements Closeable {
     public WorkLoadSettings ws;
     private final String sourcePath;
 
-    // Records come from a binary sidecar built once from the .vec source. Reading
-    // primitives back costs no text parsing, which is what previously dominated this
-    // loader's allocation; see SparseVectorStore for the detail.
+    // <vecFilePath>.idx holds one little-endian long per line: the byte offset of
+    // that line in the .vec file. It is read one entry at a time via a positional
+    // read rather than slurped into a long[] — for an 8.8M-line source that array
+    // is ~70MB, and every generator instance would hold its own private copy.
+    // Optional accelerator. When a binary sidecar exists for this source we read
+    // primitives straight out of it and skip text parsing entirely; when it does not,
+    // everything below this line is the unchanged text path. The sidecar is never
+    // built on demand -- see SparseVectorStore for why.
     private SparseVectorStore store;
+
+    // Path only, not an open channel: see offsetOf().
+    private String idxFilePath;
+
+    private FileChannel fileChannel;
+    private BufferedReader lineReader;
 
     private long rangeStart;
     private long rangeEnd;
@@ -39,27 +62,139 @@ public class MSMARCOEmbeddingProduct implements Closeable {
         this.sourcePath = resolveSourcePath(ws);
 
         try {
-            this.store = SparseVectorStore.open(sourcePath);
+            this.store = SparseVectorStore.openIfPresent(sourcePath);
+            if (store == null)
+                this.idxFilePath = ensureIndex(sourcePath);
+            this.fileChannel = FileChannel.open(Paths.get(sourcePath), StandardOpenOption.READ);
 
             if (ws.creates > 0 && ws.dr != null) {
                 initRangeBounds(ws.dr.create_s);
                 this.workerStartRecord = ws.dr.create_s;
                 this.isMutation = false;
-                this.currentRecord = ws.dr.create_s;
+                positionAt(ws.dr.create_s);
             } else if (ws.updates > 0 && ws.dr != null) {
                 initRangeBounds(ws.dr.update_s);
                 this.workerStartRecord = ws.dr.update_s;
                 this.isMutation = true;
-                this.currentRecord = rangeStart + ((workerStartRecord - rangeStart + ws.mutated) % rangeSize);
+                positionAt(rangeStart + ((workerStartRecord - rangeStart + ws.mutated) % rangeSize));
             } else if (ws.expiry > 0 && ws.dr != null) {
                 initRangeBounds(ws.dr.expiry_s);
                 this.workerStartRecord = ws.dr.expiry_s;
                 this.isMutation = true;
-                this.currentRecord = ws.dr.expiry_s;
+                positionAt(ws.dr.expiry_s);
             }
         } catch (IOException e) {
-            throw new RuntimeException("Failed to initialize MSMARCO embedding source: " + e.getMessage(), e);
+            throw new RuntimeException("Failed to initialize MSMARCO embedding stream: " + e.getMessage(), e);
         }
+    }
+
+    // Ensures the .idx sidecar exists alongside the .vec file, building it if absent,
+    // and returns its path. Synchronized to prevent concurrent workers from racing to
+    // build the same index file.
+    private static synchronized String ensureIndex(String vecFilePath) throws IOException {
+        String idxFilePath = vecFilePath + ".idx";
+        if (!Files.exists(Paths.get(idxFilePath)))
+            buildAndSaveIndex(vecFilePath, idxFilePath);
+        return idxFilePath;
+    }
+
+    // Single pass: scans .vec for newlines, streams offsets directly to .idx.
+    // Never holds all offsets in memory.
+    private static void buildAndSaveIndex(String vecFilePath, String idxFilePath) throws IOException {
+        System.out.println("Building offset index for: " + vecFilePath + " -> " + idxFilePath);
+        ByteBuffer readBuf = ByteBuffer.allocateDirect(STREAM_BUFFER_SIZE);
+        ByteBuffer writeBuf = ByteBuffer.allocate(8 * 8192).order(ByteOrder.LITTLE_ENDIAN);
+        long bytePos = 0;
+
+        // Build into a temp file and rename atomically. ensureIndex()'s exists-check only
+        // serialises workers inside one JVM; writing in place lets a second process observe
+        // a file that exists but is still being written, and read truncated offsets.
+        Path tmp = Paths.get(idxFilePath + ".tmp");
+        try {
+        try (FileChannel vecCh = FileChannel.open(Paths.get(vecFilePath), StandardOpenOption.READ);
+             FileChannel idxCh = FileChannel.open(tmp,
+                     StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)) {
+
+            // Line 0 always starts at byte 0
+            writeBuf.putLong(0L);
+
+            while (vecCh.read(readBuf) > 0) {
+                readBuf.flip();
+                while (readBuf.hasRemaining()) {
+                    byte b = readBuf.get();
+                    bytePos++;
+                    if (b == '\n') {
+                        writeBuf.putLong(bytePos);
+                        if (!writeBuf.hasRemaining()) {
+                            writeBuf.flip();
+                            idxCh.write(writeBuf);
+                            writeBuf.clear();
+                        }
+                    }
+                }
+                readBuf.clear();
+            }
+            writeBuf.flip();
+            if (writeBuf.hasRemaining())
+                idxCh.write(writeBuf);
+            idxCh.force(true);
+        }
+        Files.move(tmp, Paths.get(idxFilePath),
+                StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+        } catch (IOException e) {
+            Files.deleteIfExists(tmp);
+            throw e;
+        }
+
+        System.out.println("Index built: " + idxFilePath);
+    }
+
+    // Reads the byte offset of a single line from the .idx sidecar.
+    //
+    // The channel is opened per call rather than held for this object's lifetime. Nothing
+    // in the repo calls close() on a generator, and TaskRequest builds
+    // process_concurrency of them per request in a long-running server, so a retained
+    // channel accumulates for the JVM's lifetime -- and ulimit -n is 1024 on the volume
+    // hosts. Opening here keeps this class at the same descriptor count as before this
+    // change, where loadIndex() opened and closed the index inside try-with-resources.
+    //
+    // Not a hot path: seekToRecord() is the only caller, reached once per generator in
+    // create mode and once per iteration wrap in mutation mode, since keys arrive in
+    // ascending order and currentRecord already tracks the target.
+    private long offsetOf(long recordIndex) throws IOException {
+        ByteBuffer buf = ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN);
+        try (FileChannel idxChannel = FileChannel.open(Paths.get(idxFilePath), StandardOpenOption.READ)) {
+            long records = idxChannel.size() / 8;
+            if (recordIndex < 0 || recordIndex >= records)
+                throw new IOException("record index " + recordIndex + " out of bounds [0, " + records
+                        + ") in " + idxFilePath);
+            long pos = recordIndex * 8L;
+            while (buf.hasRemaining()) {
+                if (idxChannel.read(buf, pos + buf.position()) < 0)
+                    throw new IOException("truncated offset index at record " + recordIndex);
+            }
+        }
+        buf.flip();
+        return buf.getLong();
+    }
+
+    // O(1) seek to any record by direct byte offset lookup.
+    // Do NOT close lineReader — closing Channels.newInputStream would close fileChannel.
+    private void seekToRecord(long recordIndex) throws IOException {
+        fileChannel.position(offsetOf(recordIndex));
+        lineReader = new BufferedReader(
+                new InputStreamReader(Channels.newInputStream(fileChannel), StandardCharsets.UTF_8),
+                STREAM_BUFFER_SIZE);
+        currentRecord = recordIndex;
+    }
+
+    // With the sidecar a record is addressed by index, so positioning is just an
+    // assignment; the text path has to move the stream.
+    private void positionAt(long recordIndex) throws IOException {
+        if (store != null)
+            currentRecord = recordIndex;
+        else
+            seekToRecord(recordIndex);
     }
 
     private void initRangeBounds(long docIndex) {
@@ -79,10 +214,14 @@ public class MSMARCOEmbeddingProduct implements Closeable {
         int id = keyNum + this.ws.mutated;
 
         if (isMutation) {
-            currentRecord = rangeStart + ((keyNum - rangeStart + ws.mutated) % rangeSize);
+            long targetRecord = rangeStart + ((keyNum - rangeStart + ws.mutated) % rangeSize);
+            if (targetRecord != currentRecord) {
+                positionAt(targetRecord);
+            }
         }
 
-        Object sparseEmbedding = store.read(currentRecord);
+        Object sparseEmbedding = store != null ? store.read(currentRecord)
+                                              : readNextEmbedding();
         currentRecord++;
 
         // Metadata based on range boundaries
@@ -119,6 +258,151 @@ public class MSMARCOEmbeddingProduct implements Closeable {
         return new Product1(id, embedding, size, color, brand, country, category, type, review, ws.mutated);
     }
 
+    private Object readNextEmbedding() throws IOException {
+        if (lineReader == null) {
+            throw new IOException("Reader is null");
+        }
+        String line = lineReader.readLine();
+        if (line == null) {
+            throw new IOException("No more embedding records available from source: " + sourcePath);
+        }
+        while (isWhitespaceOnly(line)) {
+            line = lineReader.readLine();
+            if (line == null) {
+                throw new IOException("No more embedding records available from source: " + sourcePath);
+            }
+        }
+        return parseRecord(line);
+    }
+
+    // Parses one "<id>\t[indices]\t[values]" record into { int[], float[] }.
+    //
+    // The pair is kept as primitive arrays rather than List<Integer>/List<Float>: at
+    // ~300 non-zeros the boxed form costs ~12KB per document against ~2.5KB here, and
+    // every in-flight batch retains batchSize x workers of them.
+    //
+    // Returned as Object[] so Jackson still emits [[indices...],[values...]], byte for
+    // byte what the nested-List form produced.
+    private static Object parseRecord(String line) throws IOException {
+        int firstTab = line.indexOf('\t');
+        int secondTab = firstTab < 0 ? -1 : line.indexOf('\t', firstTab + 1);
+        if (secondTab < 0)
+            throw new IOException("Invalid .vec format: expected 3 tab-separated parts");
+
+        int indicesOpen = line.indexOf('[', firstTab + 1);
+        int indicesClose = line.lastIndexOf(']', secondTab);
+        int valuesOpen = line.indexOf('[', secondTab + 1);
+        int valuesClose = line.lastIndexOf(']');
+        if (indicesOpen < 0 || indicesClose < indicesOpen || valuesOpen < 0 || valuesClose < valuesOpen)
+            throw new IOException("Invalid .vec format: malformed index/value list");
+
+        int count = countElements(line, indicesOpen + 1, indicesClose);
+        int[] indices = new int[count];
+        float[] values = new float[count];
+        int indexCount = parseIndices(line, indicesOpen + 1, indicesClose, indices);
+        int valueCount = parseValues(line, valuesOpen + 1, valuesClose, values);
+        if (indexCount != valueCount) {
+            throw new IOException("Indices and values arrays have different lengths: "
+                    + indexCount + " vs " + valueCount);
+        }
+        // countElements() counts separators while the parsers skip runs of them, so an
+        // empty element -- a trailing or doubled comma -- makes count overshoot what is
+        // actually parsed. Trim to the parsed length: leaving the surplus slots at their
+        // defaults would inject a phantom index 0 / value 0.0 into the document, and the
+        // check above cannot catch it because both sides undercount identically. The
+        // split(",") this replaced dropped trailing empties, so trimming keeps that
+        // behaviour. Never taken on well-formed input.
+        if (indexCount != count) {
+            indices = Arrays.copyOf(indices, indexCount);
+            values = Arrays.copyOf(values, indexCount);
+        }
+        return new Object[] { indices, values };
+    }
+
+    // Counts comma-separated elements in [from, to); 0 if the region is whitespace only.
+    private static int countElements(String s, int from, int to) {
+        int i = from;
+        while (i < to && s.charAt(i) <= ' ')
+            i++;
+        if (i >= to)
+            return 0;
+        int count = 1;
+        for (; i < to; i++)
+            if (s.charAt(i) == ',')
+                count++;
+        return count;
+    }
+
+    // Parses the comma-separated integers in [from, to) into out. Allocation free.
+    private static int parseIndices(String s, int from, int to, int[] out) throws IOException {
+        int n = 0;
+        int i = from;
+        while (i < to) {
+            while (i < to && isSeparator(s.charAt(i)))
+                i++;
+            if (i >= to)
+                break;
+            boolean negative = s.charAt(i) == '-';
+            if (negative || s.charAt(i) == '+')
+                i++;
+            int start = i;
+            int value = 0;
+            while (i < to) {
+                char c = s.charAt(i);
+                if (c < '0' || c > '9')
+                    break;
+                value = value * 10 + (c - '0');
+                i++;
+            }
+            if (i == start)
+                throw new IOException("Invalid .vec format: malformed index at offset " + start);
+            if (n == out.length)
+                throw new IOException("Invalid .vec format: more indices than counted");
+            out[n++] = negative ? -value : value;
+        }
+        return n;
+    }
+
+    // Parses the comma-separated floats in [from, to) into out.
+    //
+    // Float.parseFloat is kept, on a per-token substring, rather than accumulating the
+    // decimal by hand: the source prints up to 17 significant digits, past the 2^53
+    // mantissa limit under which a hand-rolled accumulator is still provably correctly
+    // rounded. parseFloat is what guarantees the emitted JSON is unchanged.
+    private static int parseValues(String s, int from, int to, float[] out) throws IOException {
+        int n = 0;
+        int i = from;
+        while (i < to) {
+            while (i < to && isSeparator(s.charAt(i)))
+                i++;
+            if (i >= to)
+                break;
+            int start = i;
+            while (i < to && s.charAt(i) != ',')
+                i++;
+            int end = i;
+            while (end > start && s.charAt(end - 1) <= ' ')
+                end--;
+            if (end == start)
+                throw new IOException("Invalid .vec format: empty value at offset " + start);
+            if (n == out.length)
+                throw new IOException("Invalid .vec format: more values than indices");
+            out[n++] = Float.parseFloat(s.substring(start, end));
+        }
+        return n;
+    }
+
+    private static boolean isSeparator(char c) {
+        return c == ',' || c <= ' ';
+    }
+
+    private static boolean isWhitespaceOnly(String s) {
+        for (int i = 0; i < s.length(); i++)
+            if (s.charAt(i) > ' ')
+                return false;
+        return true;
+    }
+
     private static String encodeSparseToBase64(Object sparseEmbedding) {
         Object[] embedding = (Object[]) sparseEmbedding;
         int[] indices = (int[]) embedding[0];
@@ -151,6 +435,12 @@ public class MSMARCOEmbeddingProduct implements Closeable {
         if (store != null) {
             store.close();
             store = null;
+        }
+        // Do not close lineReader — closing Channels.newInputStream wraps would close fileChannel
+        lineReader = null;
+        if (fileChannel != null) {
+            fileChannel.close();
+            fileChannel = null;
         }
     }
 

--- a/src/main/java/utils/val/MSMARCOSiftEmbeddingProduct.java
+++ b/src/main/java/utils/val/MSMARCOSiftEmbeddingProduct.java
@@ -67,9 +67,15 @@ public class MSMARCOSiftEmbeddingProduct implements Closeable {
 
         try {
             this.store = SparseVectorStore.openIfPresent(sparseSourcePath);
-            if (store == null)
+            if (store == null) {
+                // Both belong to the text path only. Opening them anyway when the sidecar
+                // is in use would leave every generator holding a descriptor it never
+                // reads, on top of the sidecar's own -- and nothing in the repo closes a
+                // generator while ulimit -n is 1024 on the volume hosts. See offsetOf().
                 this.idxFilePath = ensureIndex(sparseSourcePath);
-            this.sparseChannel = FileChannel.open(Paths.get(sparseSourcePath), StandardOpenOption.READ);
+                this.sparseChannel = FileChannel.open(Paths.get(sparseSourcePath), StandardOpenOption.READ);
+            }
+            // The dense side is read from the binary source either way.
             this.siftChannel = FileChannel.open(Paths.get(siftSourcePath), StandardOpenOption.READ);
 
             if (ws.creates > 0 && ws.dr != null) {

--- a/src/main/java/utils/val/MSMARCOSiftEmbeddingProduct.java
+++ b/src/main/java/utils/val/MSMARCOSiftEmbeddingProduct.java
@@ -1,20 +1,12 @@
 package utils.val;
 
-import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
-import java.util.Arrays;
 import java.util.Base64;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -23,7 +15,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import utils.docgen.WorkLoadSettings;
 
 public class MSMARCOSiftEmbeddingProduct implements Closeable {
-    private static final int STREAM_BUFFER_SIZE = 1024 * 1024;
     private static final int SIFT_DIM = 128;
     private static final int SIFT_RECORD_BYTES = 4 + SIFT_DIM; // 4 bytes dim + 128 bytes data
 
@@ -35,16 +26,16 @@ public class MSMARCOSiftEmbeddingProduct implements Closeable {
     private final String sparseSourcePath;
     private final String siftSourcePath;
 
-    // Sparse: offset index file for O(1) seeks (same approach as MSMARCOEmbeddingProduct).
-    // Offsets are read one at a time via a positional read rather than slurped into a
-    // long[] — for an 8.8M-line source that array is ~70MB per generator instance.
-    // Path only, not an open channel: see offsetOf().
-    private String idxFilePath;
-    private FileChannel sparseChannel;
-    private BufferedReader sparseReader;
+    // Sparse records come from a binary sidecar built once from the .vec source; see
+    // SparseVectorStore. Reading primitives back costs no text parsing, which is what
+    // previously dominated this loader's allocation.
+    private SparseVectorStore store;
 
-    // SIFT: fixed-size records (4 + 128 = 132 bytes each), O(1) seek by position = N * 132
+    // SIFT: fixed-size records (4 + 128 = 132 bytes each), addressed positionally as
+    // recordIndex * SIFT_RECORD_BYTES so it stays in lockstep with the sparse record.
     private FileChannel siftChannel;
+    private final ByteBuffer siftBuffer =
+            ByteBuffer.allocate(SIFT_RECORD_BYTES).order(ByteOrder.LITTLE_ENDIAN);
 
     private long rangeStart;
     private long rangeEnd;
@@ -60,25 +51,24 @@ public class MSMARCOSiftEmbeddingProduct implements Closeable {
         this.siftSourcePath = resolveSiftSourcePath(ws);
 
         try {
-            this.idxFilePath = ensureIndex(sparseSourcePath);
-            this.sparseChannel = FileChannel.open(Paths.get(sparseSourcePath), StandardOpenOption.READ);
+            this.store = SparseVectorStore.open(sparseSourcePath);
             this.siftChannel = FileChannel.open(Paths.get(siftSourcePath), StandardOpenOption.READ);
 
             if (ws.creates > 0 && ws.dr != null) {
                 initRangeBounds(ws.dr.create_s);
                 this.workerStartRecord = ws.dr.create_s;
                 this.isMutation = false;
-                seekToRecord(ws.dr.create_s);
+                this.currentRecord = ws.dr.create_s;
             } else if (ws.updates > 0 && ws.dr != null) {
                 initRangeBounds(ws.dr.update_s);
                 this.workerStartRecord = ws.dr.update_s;
                 this.isMutation = true;
-                seekToRecord(rangeStart + ((workerStartRecord - rangeStart + ws.mutated) % rangeSize));
+                this.currentRecord = rangeStart + ((workerStartRecord - rangeStart + ws.mutated) % rangeSize);
             } else if (ws.expiry > 0 && ws.dr != null) {
                 initRangeBounds(ws.dr.expiry_s);
                 this.workerStartRecord = ws.dr.expiry_s;
                 this.isMutation = true;
-                seekToRecord(ws.dr.expiry_s);
+                this.currentRecord = ws.dr.expiry_s;
             }
         } catch (IOException e) {
             throw new RuntimeException("Failed to initialize MSMARCO+SIFT streams: " + e.getMessage(), e);
@@ -88,100 +78,6 @@ public class MSMARCOSiftEmbeddingProduct implements Closeable {
     // Ensures the .idx sidecar exists alongside the .vec file, building it if absent,
     // and returns its path. Synchronized to prevent concurrent workers from racing to
     // build the same index file.
-    private static synchronized String ensureIndex(String vecFilePath) throws IOException {
-        String idxFilePath = vecFilePath + ".idx";
-        if (!Files.exists(Paths.get(idxFilePath)))
-            buildAndSaveIndex(vecFilePath, idxFilePath);
-        return idxFilePath;
-    }
-
-    private static void buildAndSaveIndex(String vecFilePath, String idxFilePath) throws IOException {
-        System.out.println("Building offset index for: " + vecFilePath + " -> " + idxFilePath);
-        ByteBuffer readBuf = ByteBuffer.allocateDirect(STREAM_BUFFER_SIZE);
-        ByteBuffer writeBuf = ByteBuffer.allocate(8 * 8192).order(ByteOrder.LITTLE_ENDIAN);
-        long bytePos = 0;
-
-        // Build into a temp file and rename atomically. ensureIndex()'s exists-check only
-        // serialises workers inside one JVM; writing in place lets a second process observe
-        // a file that exists but is still being written, and read truncated offsets.
-        Path tmp = Paths.get(idxFilePath + ".tmp");
-        try {
-        try (FileChannel vecCh = FileChannel.open(Paths.get(vecFilePath), StandardOpenOption.READ);
-             FileChannel idxCh = FileChannel.open(tmp,
-                     StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)) {
-
-            writeBuf.putLong(0L);
-
-            while (vecCh.read(readBuf) > 0) {
-                readBuf.flip();
-                while (readBuf.hasRemaining()) {
-                    byte b = readBuf.get();
-                    bytePos++;
-                    if (b == '\n') {
-                        writeBuf.putLong(bytePos);
-                        if (!writeBuf.hasRemaining()) {
-                            writeBuf.flip();
-                            idxCh.write(writeBuf);
-                            writeBuf.clear();
-                        }
-                    }
-                }
-                readBuf.clear();
-            }
-            writeBuf.flip();
-            if (writeBuf.hasRemaining())
-                idxCh.write(writeBuf);
-            idxCh.force(true);
-        }
-        Files.move(tmp, Paths.get(idxFilePath),
-                StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
-        } catch (IOException e) {
-            Files.deleteIfExists(tmp);
-            throw e;
-        }
-
-        System.out.println("Index built: " + idxFilePath);
-    }
-
-    // Reads the byte offset of a single line from the .idx sidecar.
-    //
-    // The channel is opened per call rather than held for this object's lifetime. Nothing
-    // in the repo calls close() on a generator, and TaskRequest builds
-    // process_concurrency of them per request in a long-running server, so a retained
-    // channel accumulates for the JVM's lifetime -- and ulimit -n is 1024 on the volume
-    // hosts. Opening here keeps this class at the same descriptor count as before this
-    // change, where loadIndex() opened and closed the index inside try-with-resources.
-    //
-    // Not a hot path: seekToRecord() is the only caller, reached once per generator in
-    // create mode and once per iteration wrap in mutation mode, since keys arrive in
-    // ascending order and currentRecord already tracks the target.
-    private long offsetOf(long recordIndex) throws IOException {
-        ByteBuffer buf = ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN);
-        try (FileChannel idxChannel = FileChannel.open(Paths.get(idxFilePath), StandardOpenOption.READ)) {
-            long records = idxChannel.size() / 8;
-            if (recordIndex < 0 || recordIndex >= records)
-                throw new IOException("record index " + recordIndex + " out of bounds [0, " + records
-                        + ") in " + idxFilePath);
-            long pos = recordIndex * 8L;
-            while (buf.hasRemaining()) {
-                if (idxChannel.read(buf, pos + buf.position()) < 0)
-                    throw new IOException("truncated offset index at record " + recordIndex);
-            }
-        }
-        buf.flip();
-        return buf.getLong();
-    }
-
-    // Seeks both sparse and SIFT channels to the given record index in O(1).
-    private void seekToRecord(long recordIndex) throws IOException {
-        sparseChannel.position(offsetOf(recordIndex));
-        sparseReader = new BufferedReader(
-                new InputStreamReader(Channels.newInputStream(sparseChannel), StandardCharsets.UTF_8),
-                STREAM_BUFFER_SIZE);
-        siftChannel.position(recordIndex * SIFT_RECORD_BYTES);
-        currentRecord = recordIndex;
-    }
-
     private void initRangeBounds(long docIndex) {
         for (int i = 0; i < STEPS.length - 1; i++) {
             if (docIndex >= STEPS[i] && docIndex < STEPS[i + 1]) {
@@ -199,14 +95,12 @@ public class MSMARCOSiftEmbeddingProduct implements Closeable {
         int id = keyNum + this.ws.mutated;
 
         if (isMutation) {
-            long targetRecord = rangeStart + ((keyNum - rangeStart + ws.mutated) % rangeSize);
-            if (targetRecord != currentRecord) {
-                seekToRecord(targetRecord);
-            }
+            currentRecord = rangeStart + ((keyNum - rangeStart + ws.mutated) % rangeSize);
         }
 
-        Object sparseEmbedding = readNextSparseEmbedding();
-        float[] siftEmbedding = readNextSiftEmbedding();
+        // Both sources are addressed by the same record index, so they cannot drift apart.
+        Object sparseEmbedding = store.read(currentRecord);
+        float[] siftEmbedding = readSiftEmbedding(currentRecord);
         currentRecord++;
 
         if (rangeStart >= STEPS[0] && rangeEnd <= STEPS[1])
@@ -229,156 +123,14 @@ public class MSMARCOSiftEmbeddingProduct implements Closeable {
                 ws.mutated);
     }
 
-    private Object readNextSparseEmbedding() throws IOException {
-        if (sparseReader == null) {
-            throw new IOException("Sparse reader is null");
-        }
-        String line = sparseReader.readLine();
-        if (line == null) {
-            throw new IOException("No more sparse embedding records available from source: " + sparseSourcePath);
-        }
-        while (isWhitespaceOnly(line)) {
-            line = sparseReader.readLine();
-            if (line == null) {
-                throw new IOException("No more sparse embedding records available from source: " + sparseSourcePath);
-            }
-        }
-        return parseRecord(line);
-    }
-
-    // Parses one "<id>\t[indices]\t[values]" record into { int[], float[] }.
-    //
-    // The pair is kept as primitive arrays rather than List<Integer>/List<Float>: at
-    // ~300 non-zeros the boxed form costs ~12KB per document against ~2.5KB here, and
-    // every in-flight batch retains batchSize x workers of them.
-    //
-    // Returned as Object[] so Jackson still emits [[indices...],[values...]], byte for
-    // byte what the nested-List form produced.
-    private static Object parseRecord(String line) throws IOException {
-        int firstTab = line.indexOf('\t');
-        int secondTab = firstTab < 0 ? -1 : line.indexOf('\t', firstTab + 1);
-        if (secondTab < 0)
-            throw new IOException("Invalid .vec format: expected 3 tab-separated parts");
-
-        int indicesOpen = line.indexOf('[', firstTab + 1);
-        int indicesClose = line.lastIndexOf(']', secondTab);
-        int valuesOpen = line.indexOf('[', secondTab + 1);
-        int valuesClose = line.lastIndexOf(']');
-        if (indicesOpen < 0 || indicesClose < indicesOpen || valuesOpen < 0 || valuesClose < valuesOpen)
-            throw new IOException("Invalid .vec format: malformed index/value list");
-
-        int count = countElements(line, indicesOpen + 1, indicesClose);
-        int[] indices = new int[count];
-        float[] values = new float[count];
-        int indexCount = parseIndices(line, indicesOpen + 1, indicesClose, indices);
-        int valueCount = parseValues(line, valuesOpen + 1, valuesClose, values);
-        if (indexCount != valueCount) {
-            throw new IOException("Indices and values arrays have different lengths: "
-                    + indexCount + " vs " + valueCount);
-        }
-        // countElements() counts separators while the parsers skip runs of them, so an
-        // empty element -- a trailing or doubled comma -- makes count overshoot what is
-        // actually parsed. Trim to the parsed length: leaving the surplus slots at their
-        // defaults would inject a phantom index 0 / value 0.0 into the document, and the
-        // check above cannot catch it because both sides undercount identically. The
-        // split(",") this replaced dropped trailing empties, so trimming keeps that
-        // behaviour. Never taken on well-formed input.
-        if (indexCount != count) {
-            indices = Arrays.copyOf(indices, indexCount);
-            values = Arrays.copyOf(values, indexCount);
-        }
-        return new Object[] { indices, values };
-    }
-
-    // Counts comma-separated elements in [from, to); 0 if the region is whitespace only.
-    private static int countElements(String s, int from, int to) {
-        int i = from;
-        while (i < to && s.charAt(i) <= ' ')
-            i++;
-        if (i >= to)
-            return 0;
-        int count = 1;
-        for (; i < to; i++)
-            if (s.charAt(i) == ',')
-                count++;
-        return count;
-    }
-
-    // Parses the comma-separated integers in [from, to) into out. Allocation free.
-    private static int parseIndices(String s, int from, int to, int[] out) throws IOException {
-        int n = 0;
-        int i = from;
-        while (i < to) {
-            while (i < to && isSeparator(s.charAt(i)))
-                i++;
-            if (i >= to)
-                break;
-            boolean negative = s.charAt(i) == '-';
-            if (negative || s.charAt(i) == '+')
-                i++;
-            int start = i;
-            int value = 0;
-            while (i < to) {
-                char c = s.charAt(i);
-                if (c < '0' || c > '9')
-                    break;
-                value = value * 10 + (c - '0');
-                i++;
-            }
-            if (i == start)
-                throw new IOException("Invalid .vec format: malformed index at offset " + start);
-            if (n == out.length)
-                throw new IOException("Invalid .vec format: more indices than counted");
-            out[n++] = negative ? -value : value;
-        }
-        return n;
-    }
-
-    // Parses the comma-separated floats in [from, to) into out.
-    //
-    // Float.parseFloat is kept, on a per-token substring, rather than accumulating the
-    // decimal by hand: the source prints up to 17 significant digits, past the 2^53
-    // mantissa limit under which a hand-rolled accumulator is still provably correctly
-    // rounded. parseFloat is what guarantees the emitted JSON is unchanged.
-    private static int parseValues(String s, int from, int to, float[] out) throws IOException {
-        int n = 0;
-        int i = from;
-        while (i < to) {
-            while (i < to && isSeparator(s.charAt(i)))
-                i++;
-            if (i >= to)
-                break;
-            int start = i;
-            while (i < to && s.charAt(i) != ',')
-                i++;
-            int end = i;
-            while (end > start && s.charAt(end - 1) <= ' ')
-                end--;
-            if (end == start)
-                throw new IOException("Invalid .vec format: empty value at offset " + start);
-            if (n == out.length)
-                throw new IOException("Invalid .vec format: more values than indices");
-            out[n++] = Float.parseFloat(s.substring(start, end));
-        }
-        return n;
-    }
-
-    private static boolean isSeparator(char c) {
-        return c == ',' || c <= ' ';
-    }
-
-    private static boolean isWhitespaceOnly(String s) {
-        for (int i = 0; i < s.length(); i++)
-            if (s.charAt(i) > ' ')
-                return false;
-        return true;
-    }
-
-    private float[] readNextSiftEmbedding() throws IOException {
-        ByteBuffer buf = ByteBuffer.allocate(SIFT_RECORD_BYTES).order(ByteOrder.LITTLE_ENDIAN);
+    private float[] readSiftEmbedding(long recordIndex) throws IOException {
+        ByteBuffer buf = siftBuffer;
+        buf.clear();
+        long pos = recordIndex * SIFT_RECORD_BYTES;
         while (buf.hasRemaining()) {
-            int n = siftChannel.read(buf);
-            if (n < 0) throw new IOException("Unexpected EOF reading SIFT record from: " + siftSourcePath);
+            if (siftChannel.read(buf, pos + buf.position()) < 0)
+                throw new IOException("Unexpected EOF reading SIFT record " + recordIndex
+                        + " from: " + siftSourcePath);
         }
         buf.flip();
         int dim = buf.getInt();
@@ -431,10 +183,9 @@ public class MSMARCOSiftEmbeddingProduct implements Closeable {
 
     @Override
     public void close() throws IOException {
-        sparseReader = null;
-        if (sparseChannel != null) {
-            sparseChannel.close();
-            sparseChannel = null;
+        if (store != null) {
+            store.close();
+            store = null;
         }
         if (siftChannel != null) {
             siftChannel.close();

--- a/src/main/java/utils/val/MSMARCOSiftEmbeddingProduct.java
+++ b/src/main/java/utils/val/MSMARCOSiftEmbeddingProduct.java
@@ -1,12 +1,20 @@
 package utils.val;
 
+import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
 import java.util.Base64;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -15,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import utils.docgen.WorkLoadSettings;
 
 public class MSMARCOSiftEmbeddingProduct implements Closeable {
+    private static final int STREAM_BUFFER_SIZE = 1024 * 1024;
     private static final int SIFT_DIM = 128;
     private static final int SIFT_RECORD_BYTES = 4 + SIFT_DIM; // 4 bytes dim + 128 bytes data
 
@@ -26,16 +35,22 @@ public class MSMARCOSiftEmbeddingProduct implements Closeable {
     private final String sparseSourcePath;
     private final String siftSourcePath;
 
-    // Sparse records come from a binary sidecar built once from the .vec source; see
-    // SparseVectorStore. Reading primitives back costs no text parsing, which is what
-    // previously dominated this loader's allocation.
+    // Sparse: offset index file for O(1) seeks (same approach as MSMARCOEmbeddingProduct).
+    // Offsets are read one at a time via a positional read rather than slurped into a
+    // long[] — for an 8.8M-line source that array is ~70MB per generator instance.
+    // Optional accelerator. When a binary sidecar exists for this source we read
+    // primitives straight out of it and skip text parsing entirely; when it does not,
+    // everything below this line is the unchanged text path. The sidecar is never
+    // built on demand -- see SparseVectorStore for why.
     private SparseVectorStore store;
 
-    // SIFT: fixed-size records (4 + 128 = 132 bytes each), addressed positionally as
-    // recordIndex * SIFT_RECORD_BYTES so it stays in lockstep with the sparse record.
+    // Path only, not an open channel: see offsetOf().
+    private String idxFilePath;
+    private FileChannel sparseChannel;
+    private BufferedReader sparseReader;
+
+    // SIFT: fixed-size records (4 + 128 = 132 bytes each), O(1) seek by position = N * 132
     private FileChannel siftChannel;
-    private final ByteBuffer siftBuffer =
-            ByteBuffer.allocate(SIFT_RECORD_BYTES).order(ByteOrder.LITTLE_ENDIAN);
 
     private long rangeStart;
     private long rangeEnd;
@@ -51,24 +66,27 @@ public class MSMARCOSiftEmbeddingProduct implements Closeable {
         this.siftSourcePath = resolveSiftSourcePath(ws);
 
         try {
-            this.store = SparseVectorStore.open(sparseSourcePath);
+            this.store = SparseVectorStore.openIfPresent(sparseSourcePath);
+            if (store == null)
+                this.idxFilePath = ensureIndex(sparseSourcePath);
+            this.sparseChannel = FileChannel.open(Paths.get(sparseSourcePath), StandardOpenOption.READ);
             this.siftChannel = FileChannel.open(Paths.get(siftSourcePath), StandardOpenOption.READ);
 
             if (ws.creates > 0 && ws.dr != null) {
                 initRangeBounds(ws.dr.create_s);
                 this.workerStartRecord = ws.dr.create_s;
                 this.isMutation = false;
-                this.currentRecord = ws.dr.create_s;
+                positionAt(ws.dr.create_s);
             } else if (ws.updates > 0 && ws.dr != null) {
                 initRangeBounds(ws.dr.update_s);
                 this.workerStartRecord = ws.dr.update_s;
                 this.isMutation = true;
-                this.currentRecord = rangeStart + ((workerStartRecord - rangeStart + ws.mutated) % rangeSize);
+                positionAt(rangeStart + ((workerStartRecord - rangeStart + ws.mutated) % rangeSize));
             } else if (ws.expiry > 0 && ws.dr != null) {
                 initRangeBounds(ws.dr.expiry_s);
                 this.workerStartRecord = ws.dr.expiry_s;
                 this.isMutation = true;
-                this.currentRecord = ws.dr.expiry_s;
+                positionAt(ws.dr.expiry_s);
             }
         } catch (IOException e) {
             throw new RuntimeException("Failed to initialize MSMARCO+SIFT streams: " + e.getMessage(), e);
@@ -78,6 +96,113 @@ public class MSMARCOSiftEmbeddingProduct implements Closeable {
     // Ensures the .idx sidecar exists alongside the .vec file, building it if absent,
     // and returns its path. Synchronized to prevent concurrent workers from racing to
     // build the same index file.
+    private static synchronized String ensureIndex(String vecFilePath) throws IOException {
+        String idxFilePath = vecFilePath + ".idx";
+        if (!Files.exists(Paths.get(idxFilePath)))
+            buildAndSaveIndex(vecFilePath, idxFilePath);
+        return idxFilePath;
+    }
+
+    private static void buildAndSaveIndex(String vecFilePath, String idxFilePath) throws IOException {
+        System.out.println("Building offset index for: " + vecFilePath + " -> " + idxFilePath);
+        ByteBuffer readBuf = ByteBuffer.allocateDirect(STREAM_BUFFER_SIZE);
+        ByteBuffer writeBuf = ByteBuffer.allocate(8 * 8192).order(ByteOrder.LITTLE_ENDIAN);
+        long bytePos = 0;
+
+        // Build into a temp file and rename atomically. ensureIndex()'s exists-check only
+        // serialises workers inside one JVM; writing in place lets a second process observe
+        // a file that exists but is still being written, and read truncated offsets.
+        Path tmp = Paths.get(idxFilePath + ".tmp");
+        try {
+        try (FileChannel vecCh = FileChannel.open(Paths.get(vecFilePath), StandardOpenOption.READ);
+             FileChannel idxCh = FileChannel.open(tmp,
+                     StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)) {
+
+            writeBuf.putLong(0L);
+
+            while (vecCh.read(readBuf) > 0) {
+                readBuf.flip();
+                while (readBuf.hasRemaining()) {
+                    byte b = readBuf.get();
+                    bytePos++;
+                    if (b == '\n') {
+                        writeBuf.putLong(bytePos);
+                        if (!writeBuf.hasRemaining()) {
+                            writeBuf.flip();
+                            idxCh.write(writeBuf);
+                            writeBuf.clear();
+                        }
+                    }
+                }
+                readBuf.clear();
+            }
+            writeBuf.flip();
+            if (writeBuf.hasRemaining())
+                idxCh.write(writeBuf);
+            idxCh.force(true);
+        }
+        Files.move(tmp, Paths.get(idxFilePath),
+                StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+        } catch (IOException e) {
+            Files.deleteIfExists(tmp);
+            throw e;
+        }
+
+        System.out.println("Index built: " + idxFilePath);
+    }
+
+    // Reads the byte offset of a single line from the .idx sidecar.
+    //
+    // The channel is opened per call rather than held for this object's lifetime. Nothing
+    // in the repo calls close() on a generator, and TaskRequest builds
+    // process_concurrency of them per request in a long-running server, so a retained
+    // channel accumulates for the JVM's lifetime -- and ulimit -n is 1024 on the volume
+    // hosts. Opening here keeps this class at the same descriptor count as before this
+    // change, where loadIndex() opened and closed the index inside try-with-resources.
+    //
+    // Not a hot path: seekToRecord() is the only caller, reached once per generator in
+    // create mode and once per iteration wrap in mutation mode, since keys arrive in
+    // ascending order and currentRecord already tracks the target.
+    private long offsetOf(long recordIndex) throws IOException {
+        ByteBuffer buf = ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN);
+        try (FileChannel idxChannel = FileChannel.open(Paths.get(idxFilePath), StandardOpenOption.READ)) {
+            long records = idxChannel.size() / 8;
+            if (recordIndex < 0 || recordIndex >= records)
+                throw new IOException("record index " + recordIndex + " out of bounds [0, " + records
+                        + ") in " + idxFilePath);
+            long pos = recordIndex * 8L;
+            while (buf.hasRemaining()) {
+                if (idxChannel.read(buf, pos + buf.position()) < 0)
+                    throw new IOException("truncated offset index at record " + recordIndex);
+            }
+        }
+        buf.flip();
+        return buf.getLong();
+    }
+
+    // Seeks both sparse and SIFT channels to the given record index in O(1).
+    private void seekToRecord(long recordIndex) throws IOException {
+        sparseChannel.position(offsetOf(recordIndex));
+        sparseReader = new BufferedReader(
+                new InputStreamReader(Channels.newInputStream(sparseChannel), StandardCharsets.UTF_8),
+                STREAM_BUFFER_SIZE);
+        siftChannel.position(recordIndex * SIFT_RECORD_BYTES);
+        currentRecord = recordIndex;
+    }
+
+    // With the sidecar a record is addressed by index, so positioning is just an
+    // assignment; the text path has to move the stream.
+    private void positionAt(long recordIndex) throws IOException {
+        if (store != null) {
+            currentRecord = recordIndex;
+            // The sparse side is index-addressed, but the SIFT side is still read
+            // sequentially, so it has to be moved in step or the dense vectors drift.
+            siftChannel.position(recordIndex * SIFT_RECORD_BYTES);
+        } else {
+            seekToRecord(recordIndex);
+        }
+    }
+
     private void initRangeBounds(long docIndex) {
         for (int i = 0; i < STEPS.length - 1; i++) {
             if (docIndex >= STEPS[i] && docIndex < STEPS[i + 1]) {
@@ -95,12 +220,15 @@ public class MSMARCOSiftEmbeddingProduct implements Closeable {
         int id = keyNum + this.ws.mutated;
 
         if (isMutation) {
-            currentRecord = rangeStart + ((keyNum - rangeStart + ws.mutated) % rangeSize);
+            long targetRecord = rangeStart + ((keyNum - rangeStart + ws.mutated) % rangeSize);
+            if (targetRecord != currentRecord) {
+                positionAt(targetRecord);
+            }
         }
 
-        // Both sources are addressed by the same record index, so they cannot drift apart.
-        Object sparseEmbedding = store.read(currentRecord);
-        float[] siftEmbedding = readSiftEmbedding(currentRecord);
+        Object sparseEmbedding = store != null ? store.read(currentRecord)
+                                              : readNextSparseEmbedding();
+        float[] siftEmbedding = readNextSiftEmbedding();
         currentRecord++;
 
         if (rangeStart >= STEPS[0] && rangeEnd <= STEPS[1])
@@ -123,14 +251,156 @@ public class MSMARCOSiftEmbeddingProduct implements Closeable {
                 ws.mutated);
     }
 
-    private float[] readSiftEmbedding(long recordIndex) throws IOException {
-        ByteBuffer buf = siftBuffer;
-        buf.clear();
-        long pos = recordIndex * SIFT_RECORD_BYTES;
+    private Object readNextSparseEmbedding() throws IOException {
+        if (sparseReader == null) {
+            throw new IOException("Sparse reader is null");
+        }
+        String line = sparseReader.readLine();
+        if (line == null) {
+            throw new IOException("No more sparse embedding records available from source: " + sparseSourcePath);
+        }
+        while (isWhitespaceOnly(line)) {
+            line = sparseReader.readLine();
+            if (line == null) {
+                throw new IOException("No more sparse embedding records available from source: " + sparseSourcePath);
+            }
+        }
+        return parseRecord(line);
+    }
+
+    // Parses one "<id>\t[indices]\t[values]" record into { int[], float[] }.
+    //
+    // The pair is kept as primitive arrays rather than List<Integer>/List<Float>: at
+    // ~300 non-zeros the boxed form costs ~12KB per document against ~2.5KB here, and
+    // every in-flight batch retains batchSize x workers of them.
+    //
+    // Returned as Object[] so Jackson still emits [[indices...],[values...]], byte for
+    // byte what the nested-List form produced.
+    private static Object parseRecord(String line) throws IOException {
+        int firstTab = line.indexOf('\t');
+        int secondTab = firstTab < 0 ? -1 : line.indexOf('\t', firstTab + 1);
+        if (secondTab < 0)
+            throw new IOException("Invalid .vec format: expected 3 tab-separated parts");
+
+        int indicesOpen = line.indexOf('[', firstTab + 1);
+        int indicesClose = line.lastIndexOf(']', secondTab);
+        int valuesOpen = line.indexOf('[', secondTab + 1);
+        int valuesClose = line.lastIndexOf(']');
+        if (indicesOpen < 0 || indicesClose < indicesOpen || valuesOpen < 0 || valuesClose < valuesOpen)
+            throw new IOException("Invalid .vec format: malformed index/value list");
+
+        int count = countElements(line, indicesOpen + 1, indicesClose);
+        int[] indices = new int[count];
+        float[] values = new float[count];
+        int indexCount = parseIndices(line, indicesOpen + 1, indicesClose, indices);
+        int valueCount = parseValues(line, valuesOpen + 1, valuesClose, values);
+        if (indexCount != valueCount) {
+            throw new IOException("Indices and values arrays have different lengths: "
+                    + indexCount + " vs " + valueCount);
+        }
+        // countElements() counts separators while the parsers skip runs of them, so an
+        // empty element -- a trailing or doubled comma -- makes count overshoot what is
+        // actually parsed. Trim to the parsed length: leaving the surplus slots at their
+        // defaults would inject a phantom index 0 / value 0.0 into the document, and the
+        // check above cannot catch it because both sides undercount identically. The
+        // split(",") this replaced dropped trailing empties, so trimming keeps that
+        // behaviour. Never taken on well-formed input.
+        if (indexCount != count) {
+            indices = Arrays.copyOf(indices, indexCount);
+            values = Arrays.copyOf(values, indexCount);
+        }
+        return new Object[] { indices, values };
+    }
+
+    // Counts comma-separated elements in [from, to); 0 if the region is whitespace only.
+    private static int countElements(String s, int from, int to) {
+        int i = from;
+        while (i < to && s.charAt(i) <= ' ')
+            i++;
+        if (i >= to)
+            return 0;
+        int count = 1;
+        for (; i < to; i++)
+            if (s.charAt(i) == ',')
+                count++;
+        return count;
+    }
+
+    // Parses the comma-separated integers in [from, to) into out. Allocation free.
+    private static int parseIndices(String s, int from, int to, int[] out) throws IOException {
+        int n = 0;
+        int i = from;
+        while (i < to) {
+            while (i < to && isSeparator(s.charAt(i)))
+                i++;
+            if (i >= to)
+                break;
+            boolean negative = s.charAt(i) == '-';
+            if (negative || s.charAt(i) == '+')
+                i++;
+            int start = i;
+            int value = 0;
+            while (i < to) {
+                char c = s.charAt(i);
+                if (c < '0' || c > '9')
+                    break;
+                value = value * 10 + (c - '0');
+                i++;
+            }
+            if (i == start)
+                throw new IOException("Invalid .vec format: malformed index at offset " + start);
+            if (n == out.length)
+                throw new IOException("Invalid .vec format: more indices than counted");
+            out[n++] = negative ? -value : value;
+        }
+        return n;
+    }
+
+    // Parses the comma-separated floats in [from, to) into out.
+    //
+    // Float.parseFloat is kept, on a per-token substring, rather than accumulating the
+    // decimal by hand: the source prints up to 17 significant digits, past the 2^53
+    // mantissa limit under which a hand-rolled accumulator is still provably correctly
+    // rounded. parseFloat is what guarantees the emitted JSON is unchanged.
+    private static int parseValues(String s, int from, int to, float[] out) throws IOException {
+        int n = 0;
+        int i = from;
+        while (i < to) {
+            while (i < to && isSeparator(s.charAt(i)))
+                i++;
+            if (i >= to)
+                break;
+            int start = i;
+            while (i < to && s.charAt(i) != ',')
+                i++;
+            int end = i;
+            while (end > start && s.charAt(end - 1) <= ' ')
+                end--;
+            if (end == start)
+                throw new IOException("Invalid .vec format: empty value at offset " + start);
+            if (n == out.length)
+                throw new IOException("Invalid .vec format: more values than indices");
+            out[n++] = Float.parseFloat(s.substring(start, end));
+        }
+        return n;
+    }
+
+    private static boolean isSeparator(char c) {
+        return c == ',' || c <= ' ';
+    }
+
+    private static boolean isWhitespaceOnly(String s) {
+        for (int i = 0; i < s.length(); i++)
+            if (s.charAt(i) > ' ')
+                return false;
+        return true;
+    }
+
+    private float[] readNextSiftEmbedding() throws IOException {
+        ByteBuffer buf = ByteBuffer.allocate(SIFT_RECORD_BYTES).order(ByteOrder.LITTLE_ENDIAN);
         while (buf.hasRemaining()) {
-            if (siftChannel.read(buf, pos + buf.position()) < 0)
-                throw new IOException("Unexpected EOF reading SIFT record " + recordIndex
-                        + " from: " + siftSourcePath);
+            int n = siftChannel.read(buf);
+            if (n < 0) throw new IOException("Unexpected EOF reading SIFT record from: " + siftSourcePath);
         }
         buf.flip();
         int dim = buf.getInt();
@@ -186,6 +456,11 @@ public class MSMARCOSiftEmbeddingProduct implements Closeable {
         if (store != null) {
             store.close();
             store = null;
+        }
+        sparseReader = null;
+        if (sparseChannel != null) {
+            sparseChannel.close();
+            sparseChannel = null;
         }
         if (siftChannel != null) {
             siftChannel.close();

--- a/src/main/java/utils/val/SparseVectorStore.java
+++ b/src/main/java/utils/val/SparseVectorStore.java
@@ -58,6 +58,15 @@ import java.util.Arrays;
  * it is read one entry at a time by positional read -- an 8.8M-record source would need a
  * ~70MB {@code long[]} to hold it, per instance.
  *
+ * <p>The sidecar is an accelerator, never a prerequisite: {@link #openIfPresent} returns
+ * null when one is absent and the caller falls back to reading the text source. It is
+ * deliberately never built on demand. Building takes a full pass over the source -- on the
+ * order of ten minutes for 47GB -- and the loader is constructed inside an HTTP request
+ * handler on the REST path, where that blocks the request until the client times out and
+ * the thread is interrupted. An interrupt closes a FileChannel mid-write
+ * (ClosedByInterruptException) and leaves the interrupt flag set, so every later attempt
+ * fails immediately too. Build it with {@link #main} instead.
+ *
  * <p>Not thread safe: {@link #read} reuses internal buffers. Each generator owns its own
  * instance, and the generators serialise their own {@code next()} calls.
  */
@@ -89,6 +98,9 @@ public final class SparseVectorStore implements Closeable {
     private static final int[] NO_INDICES = new int[0];
     private static final float[] NO_VALUES = new float[0];
 
+    private static final java.util.concurrent.atomic.AtomicBoolean ANNOUNCED =
+            new java.util.concurrent.atomic.AtomicBoolean();
+
     private final String binPath;
     private final FileChannel channel;
     private final long recordCount;
@@ -113,11 +125,18 @@ public final class SparseVectorStore implements Closeable {
     }
 
     /**
-     * Opens the sidecar for {@code vecFilePath}, building it first if it is missing or
-     * unusable. Building is a one-off full pass over the text source.
+     * Opens the sidecar for {@code vecFilePath} if a usable one exists, else returns null so
+     * the caller can fall back to the text source. Never builds.
      */
-    public static SparseVectorStore open(String vecFilePath) throws IOException {
-        String path = ensureSidecar(vecFilePath, resolveSidecarPath(vecFilePath));
+    public static SparseVectorStore openIfPresent(String vecFilePath) throws IOException {
+        String path = sidecarPath(vecFilePath);
+        if (!isUsable(path, Files.size(Paths.get(vecFilePath)))) {
+            if (ANNOUNCED.compareAndSet(false, true))
+                System.out.println("No sparse vector sidecar at " + path
+                        + "; reading the text source. Build one with:  java -cp <jar> "
+                        + SparseVectorStore.class.getName() + " " + vecFilePath);
+            return null;
+        }
         FileChannel ch = FileChannel.open(Paths.get(path), StandardOpenOption.READ);
         try {
             ByteBuffer header = ByteBuffer.allocate(HEADER_BYTES).order(ByteOrder.LITTLE_ENDIAN);
@@ -219,54 +238,61 @@ public final class SparseVectorStore implements Closeable {
     /* ---------------------------------------------------------------- build */
 
     /**
-     * Returns the sidecar path, building it if absent or unusable. Synchronized so
-     * concurrent generators in one JVM build it once; across JVMs the build writes to a
-     * temp file and renames atomically, so a racing build is wasteful but not corrupting.
+     * Where the sidecar for this source lives: an explicit -Dmsmarco.sidecar.dir if set,
+     * otherwise beside the source.
+     *
+     * <p>Deliberately not derived from the working directory. Doing so made the location
+     * depend on who started the JVM -- the REST server and the CLI resolved to different
+     * directories for the same source and each rebuilt its own 13GB copy.
+     *
+     * <p>Away from the source the file name carries a hash of the source's absolute path,
+     * so two sources sharing a base name cannot collide.
      */
-    private static synchronized String ensureSidecar(String vecFilePath, String binPath) throws IOException {
-        if (isUsable(binPath, Files.size(Paths.get(vecFilePath))))
-            return binPath;
-        build(vecFilePath, binPath);
-        return binPath;
+    static String sidecarPath(String vecFilePath) {
+        Path source = Paths.get(vecFilePath).toAbsolutePath();
+        String configured = System.getProperty(SIDECAR_DIR_PROPERTY);
+        if (configured != null && !configured.trim().isEmpty())
+            return Paths.get(configured.trim())
+                    .resolve(source.getFileName() + "."
+                            + Integer.toHexString(source.toString().hashCode()) + BIN_SUFFIX)
+                    .toString();
+        return vecFilePath + BIN_SUFFIX;
     }
 
     /**
-     * Picks where the sidecar lives. Next to the source is preferred so it is shared, but
-     * that directory is frequently a read-only or root-squashed export, so fall back
-     * rather than failing the load. An explicit -Dmsmarco.sidecar.dir wins over both.
-     *
-     * <p>Away from the source the file name carries a hash of the source's absolute path,
-     * so two sources with the same base name cannot collide.
+     * Builds the sidecar for {@code vecFilePath}, replacing any existing one. Intended to be
+     * run deliberately, not from a request-serving thread.
      */
-    private static String resolveSidecarPath(String vecFilePath) throws IOException {
-        Path source = Paths.get(vecFilePath).toAbsolutePath();
-        String name = source.getFileName().toString();
-
-        String configured = System.getProperty(SIDECAR_DIR_PROPERTY);
-        if (configured != null && !configured.trim().isEmpty())
-            return sidecarIn(Paths.get(configured.trim()), name, source, "-D" + SIDECAR_DIR_PROPERTY);
-
-        Path beside = source.getParent();
-        if (beside != null && Files.isWritable(beside))
-            return vecFilePath + BIN_SUFFIX;
-
-        Path working = Paths.get(System.getProperty("user.dir")).toAbsolutePath();
-        if (Files.isWritable(working)) {
-            System.out.println("Sidecar: " + beside + " is not writable, using " + working
-                    + " (set -D" + SIDECAR_DIR_PROPERTY + "=<dir> to choose another)");
-            return sidecarIn(working, name, source, "working directory");
-        }
-        throw new IOException("No writable location for the sparse vector sidecar; tried "
-                + beside + " and " + working + ". Set -D" + SIDECAR_DIR_PROPERTY + "=<dir>.");
+    public static void buildSidecar(String vecFilePath) throws IOException {
+        String path = sidecarPath(vecFilePath);
+        Path dir = Paths.get(path).toAbsolutePath().getParent();
+        if (dir != null && !Files.isDirectory(dir))
+            Files.createDirectories(dir);
+        if (dir != null && !Files.isWritable(dir))
+            throw new IOException("Sidecar directory " + dir + " is not writable. Set -D"
+                    + SIDECAR_DIR_PROPERTY + "=<dir> to choose a writable one.");
+        if (Thread.currentThread().isInterrupted())
+            throw new IOException("Refusing to build: this thread is already interrupted, and"
+                    + " channel writes would fail immediately.");
+        build(vecFilePath, path);
     }
 
-    private static String sidecarIn(Path dir, String name, Path source, String why) throws IOException {
-        if (!Files.isDirectory(dir))
-            Files.createDirectories(dir);
-        if (!Files.isWritable(dir))
-            throw new IOException("Sidecar directory " + dir + " (" + why + ") is not writable");
-        String tag = Integer.toHexString(source.toString().hashCode());
-        return dir.resolve(name + "." + tag + BIN_SUFFIX).toString();
+    /** Builds the sidecar for the given .vec source. */
+    public static void main(String[] args) throws Exception {
+        if (args.length != 1) {
+            System.err.println("usage: " + SparseVectorStore.class.getName() + " <path-to-.vec>");
+            System.err.println("       -D" + SIDECAR_DIR_PROPERTY
+                    + "=<dir> to place the sidecar somewhere other than beside the source");
+            System.exit(2);
+        }
+        long started = System.currentTimeMillis();
+        String path = sidecarPath(args[0]);
+        if (isUsable(path, Files.size(Paths.get(args[0])))) {
+            System.out.println("Sidecar already present and current: " + path);
+            return;
+        }
+        buildSidecar(args[0]);
+        System.out.println("Built in " + ((System.currentTimeMillis() - started) / 1000) + "s");
     }
 
     /** Cheap structural check: right magic and version, and the header agrees with the size. */

--- a/src/main/java/utils/val/SparseVectorStore.java
+++ b/src/main/java/utils/val/SparseVectorStore.java
@@ -14,6 +14,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
 
 /**
  * Random-access reader for the MSMARCO sparse vector source, backed by a binary sidecar
@@ -467,6 +468,16 @@ public final class SparseVectorStore implements Closeable {
         if (indexCount != valueCount)
             throw new IOException("Indices and values arrays have different lengths: "
                     + indexCount + " vs " + valueCount);
+        // countElements() counts separators while the parsers skip runs of them, so an
+        // empty element -- a trailing or doubled comma -- makes count overshoot what is
+        // actually parsed. Trim to the parsed length: leaving the surplus slots at their
+        // defaults would bake a phantom index 0 / value 0.0 into the sidecar, and the
+        // check above cannot catch it because both sides undercount identically. Never
+        // taken on well-formed input.
+        if (indexCount != count) {
+            indices = Arrays.copyOf(indices, indexCount);
+            values = Arrays.copyOf(values, indexCount);
+        }
         return new Object[] { indices, values };
     }
 

--- a/src/main/java/utils/val/SparseVectorStore.java
+++ b/src/main/java/utils/val/SparseVectorStore.java
@@ -1,0 +1,498 @@
+package utils.val;
+
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+
+/**
+ * Random-access reader for the MSMARCO sparse vector source, backed by a binary sidecar
+ * built once from the text .vec file.
+ *
+ * <p>Motivation: the text source prints each value at up to 17 significant digits. That is
+ * past the fast path in {@code FloatingDecimal.readJavaFormatString}, so every
+ * {@code Float.parseFloat} call drops into the arbitrary-precision correction loop backed
+ * by {@code sun.misc.FDBigInteger}. A live heap histogram taken mid-load showed 11.7M
+ * FDBigInteger and 3.6M FloatingDecimal$ASCIIToBinaryBuffer instances -- roughly 1.19GB of
+ * pure parser scratch -- which is what drove ParallelGC's adaptive sizing to inflate eden
+ * to 2.58GB chasing its GCTimeRatio goal. Parsing once into a binary sidecar removes that
+ * allocation from every subsequent load entirely.
+ *
+ * <p>Values are bit-exact: the sidecar stores the {@code float} that
+ * {@code Float.parseFloat} already produced, so documents generated from it are identical
+ * to those generated from the text.
+ *
+ * <p>File layout, little-endian throughout:
+ *
+ * <pre>
+ *   0                    header, {@value #HEADER_BYTES} bytes
+ *                          long magic       = MAGIC
+ *                          int  version     = VERSION
+ *                          int  reserved    = 0
+ *                          long recordCount
+ *                          long tableOffset
+ *   {@value #HEADER_BYTES}  record data, records back to back
+ *   tableOffset          offset table, (recordCount + 1) longs
+ *                          entry[i] = absolute offset of record i
+ *                          entry[recordCount] = end of data == tableOffset
+ *
+ *   record i:
+ *     int   nnz
+ *     int   indices[nnz]
+ *     float values[nnz]
+ * </pre>
+ *
+ * <p>The table is written after the data so the build needs no advance record count, and
+ * it is read one entry at a time by positional read -- an 8.8M-record source would need a
+ * ~70MB {@code long[]} to hold it, per instance.
+ *
+ * <p>Not thread safe: {@link #read} reuses internal buffers. Each generator owns its own
+ * instance, and the generators serialise their own {@code next()} calls.
+ */
+public final class SparseVectorStore implements Closeable {
+
+    /** ASCII "MSV_SP01". */
+    private static final long MAGIC = 0x4D53565F53503031L;
+    private static final int VERSION = 1;
+    private static final int HEADER_BYTES = 32;
+
+    private static final String BIN_SUFFIX = ".bin";
+    private static final String TMP_SUFFIX = ".tmp";
+    private static final String TABLE_TMP_SUFFIX = ".table.tmp";
+
+    /** Guards against absurd allocations if a sidecar is truncated or corrupt. */
+    private static final int MAX_NNZ = 1 << 20;
+
+    private static final int INITIAL_RECORD_BUFFER = 16 * 1024;
+
+    // Build-time only.
+    private static final int TEXT_READ_BUFFER = 1 << 20;
+    private static final int DATA_WRITE_BUFFER = 1 << 20;
+    private static final int TABLE_WRITE_ENTRIES = 8192;
+    private static final long PROGRESS_INTERVAL = 1000000L;
+
+    private static final int[] NO_INDICES = new int[0];
+    private static final float[] NO_VALUES = new float[0];
+
+    private final String binPath;
+    private final FileChannel channel;
+    private final long recordCount;
+    private final long tableOffset;
+
+    // Reused across reads, and direct: FileChannel.read() into a heap buffer copies via a
+    // temporary direct buffer it has to allocate, which measured ~1.1KB of churn per
+    // record. Direct buffers read straight through, so a read now allocates nothing
+    // beyond the two arrays it returns.
+    //
+    // The offset pair buffer holds entries i and i+1, which are adjacent in the table, so
+    // one 16-byte read locates a record instead of two 8-byte reads.
+    private final ByteBuffer offsetPair = ByteBuffer.allocateDirect(16).order(ByteOrder.LITTLE_ENDIAN);
+    private ByteBuffer recordView = ByteBuffer.allocateDirect(INITIAL_RECORD_BUFFER)
+            .order(ByteOrder.LITTLE_ENDIAN);
+
+    private SparseVectorStore(String binPath, FileChannel channel, long recordCount, long tableOffset) {
+        this.binPath = binPath;
+        this.channel = channel;
+        this.recordCount = recordCount;
+        this.tableOffset = tableOffset;
+    }
+
+    /**
+     * Opens the sidecar for {@code vecFilePath}, building it first if it is missing or
+     * unusable. Building is a one-off full pass over the text source.
+     */
+    public static SparseVectorStore open(String vecFilePath) throws IOException {
+        String path = ensureSidecar(vecFilePath);
+        FileChannel ch = FileChannel.open(Paths.get(path), StandardOpenOption.READ);
+        try {
+            ByteBuffer header = ByteBuffer.allocate(HEADER_BYTES).order(ByteOrder.LITTLE_ENDIAN);
+            readFully(ch, header, 0L, "header of " + path);
+            header.flip();
+
+            long magic = header.getLong();
+            int version = header.getInt();
+            header.getInt(); // reserved
+            long count = header.getLong();
+            long table = header.getLong();
+
+            if (magic != MAGIC)
+                throw new IOException("Not a sparse vector sidecar: " + path);
+            if (version != VERSION)
+                throw new IOException("Sidecar " + path + " is version " + version
+                        + ", this build expects " + VERSION + "; delete it to rebuild");
+            if (count < 0 || table < HEADER_BYTES || table + 8L * (count + 1) != ch.size())
+                throw new IOException("Sidecar " + path + " has an inconsistent header"
+                        + " (records=" + count + ", tableOffset=" + table + ", size=" + ch.size() + ")");
+
+            return new SparseVectorStore(path, ch, count, table);
+        } catch (IOException e) {
+            ch.close();
+            throw e;
+        } catch (RuntimeException e) {
+            ch.close();
+            throw e;
+        }
+    }
+
+    /** Number of records available, i.e. lines in the source. */
+    public long recordCount() {
+        return recordCount;
+    }
+
+    /**
+     * Reads record {@code recordIndex} as {@code { int[] indices, float[] values }}.
+     *
+     * <p>Returned as {@code Object[]} because that is what Jackson renders as
+     * {@code [[indices...],[values...]]} -- the shape the generated documents have always
+     * had. Only the two primitive arrays are allocated; the read itself is buffer-reusing.
+     */
+    public Object[] read(long recordIndex) throws IOException {
+        if (recordIndex < 0 || recordIndex >= recordCount)
+            throw new IOException("record index " + recordIndex + " out of bounds [0, "
+                    + recordCount + ") in " + binPath);
+
+        // Entries recordIndex and recordIndex+1 are adjacent, so one read bounds the
+        // record. The table always carries a trailing sentinel, so i+1 is in range.
+        offsetPair.clear();
+        readFully(channel, offsetPair, tableOffset + recordIndex * 8L,
+                "offset table entries " + recordIndex + ".." + (recordIndex + 1) + " of " + binPath);
+        long from = offsetPair.getLong(0);
+        long to = offsetPair.getLong(8);
+
+        long span = to - from;
+        if (span < 4 || span > Integer.MAX_VALUE)
+            throw new IOException("corrupt record length " + span + " at record " + recordIndex
+                    + " in " + binPath);
+
+        int length = (int) span;
+        if (length > recordView.capacity()) {
+            int grown = recordView.capacity();
+            while (grown < length)
+                grown <<= 1;
+            recordView = ByteBuffer.allocateDirect(grown).order(ByteOrder.LITTLE_ENDIAN);
+        }
+
+        recordView.clear();
+        recordView.limit(length);
+        readFully(channel, recordView, from, "record " + recordIndex + " of " + binPath);
+
+        int nnz = recordView.getInt(0);
+        if (nnz < 0 || nnz > MAX_NNZ)
+            throw new IOException("record " + recordIndex + " declares nnz=" + nnz + " in " + binPath);
+        if (4L + 8L * nnz != length)
+            throw new IOException("record " + recordIndex + " declares nnz=" + nnz + " (" + (4L + 8L * nnz)
+                    + " bytes) but spans " + length + " bytes in " + binPath);
+
+        int offset = 4;
+        int[] indices = new int[nnz];
+        for (int i = 0; i < nnz; i++, offset += 4)
+            indices[i] = recordView.getInt(offset);
+
+        float[] values = new float[nnz];
+        for (int i = 0; i < nnz; i++, offset += 4)
+            values[i] = recordView.getFloat(offset);
+
+        return new Object[] { indices, values };
+    }
+
+    @Override
+    public void close() throws IOException {
+        channel.close();
+    }
+
+    /* ---------------------------------------------------------------- build */
+
+    /**
+     * Returns the sidecar path, building it if absent or unusable. Synchronized so
+     * concurrent generators in one JVM build it once; across JVMs the build writes to a
+     * temp file and renames atomically, so a racing build is wasteful but not corrupting.
+     */
+    private static synchronized String ensureSidecar(String vecFilePath) throws IOException {
+        String binPath = vecFilePath + BIN_SUFFIX;
+        if (isUsable(binPath))
+            return binPath;
+        build(vecFilePath, binPath);
+        return binPath;
+    }
+
+    /** Cheap structural check: right magic and version, and the header agrees with the size. */
+    private static boolean isUsable(String binPath) {
+        Path path = Paths.get(binPath);
+        if (!Files.exists(path))
+            return false;
+        try (FileChannel ch = FileChannel.open(path, StandardOpenOption.READ)) {
+            if (ch.size() < HEADER_BYTES)
+                return false;
+            ByteBuffer header = ByteBuffer.allocate(HEADER_BYTES).order(ByteOrder.LITTLE_ENDIAN);
+            readFully(ch, header, 0L, binPath);
+            header.flip();
+            if (header.getLong() != MAGIC || header.getInt() != VERSION)
+                return false;
+            header.getInt(); // reserved
+            long count = header.getLong();
+            long table = header.getLong();
+            return count >= 0 && table >= HEADER_BYTES && table + 8L * (count + 1) == ch.size();
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Single pass over the text source: parse each line, append its binary record, and
+     * stream the record offsets to a side file. The offset table is appended afterwards,
+     * which is why no advance record count is needed.
+     */
+    private static void build(String vecFilePath, String binPath) throws IOException {
+        Path tmp = Paths.get(binPath + TMP_SUFFIX);
+        Path tableTmp = Paths.get(binPath + TABLE_TMP_SUFFIX);
+
+        System.out.println("Building sparse vector sidecar: " + vecFilePath + " -> " + binPath);
+        System.out.println("  one-off; subsequent loads read it directly and do no text parsing");
+
+        long records = 0;
+        long blank = 0;
+        long dataPos = HEADER_BYTES;
+        long tablePos = 0;
+
+        ByteBuffer dataBuf = ByteBuffer.allocate(DATA_WRITE_BUFFER).order(ByteOrder.LITTLE_ENDIAN);
+        ByteBuffer tableBuf = ByteBuffer.allocate(8 * TABLE_WRITE_ENTRIES).order(ByteOrder.LITTLE_ENDIAN);
+
+        try {
+            try (FileChannel out = FileChannel.open(tmp, StandardOpenOption.CREATE,
+                            StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
+                    FileChannel table = FileChannel.open(tableTmp, StandardOpenOption.CREATE,
+                            StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
+                    BufferedReader in = new BufferedReader(new InputStreamReader(
+                            new FileInputStream(vecFilePath), StandardCharsets.UTF_8), TEXT_READ_BUFFER)) {
+
+                String line;
+                while ((line = in.readLine()) != null) {
+                    int[] indices;
+                    float[] values;
+                    if (isWhitespaceOnly(line)) {
+                        // Keep the record/line mapping 1:1 rather than skipping, so a record
+                        // index always addresses the line with the same number.
+                        indices = NO_INDICES;
+                        values = NO_VALUES;
+                        blank++;
+                    } else {
+                        Object[] parsed = parseTextRecord(line);
+                        indices = (int[]) parsed[0];
+                        values = (float[]) parsed[1];
+                    }
+
+                    int recordBytes = 4 + 8 * indices.length;
+                    if (recordBytes > dataBuf.capacity()) {
+                        dataPos = flush(out, dataBuf, dataPos);
+                        dataBuf = ByteBuffer.allocate(recordBytes).order(ByteOrder.LITTLE_ENDIAN);
+                    } else if (recordBytes > dataBuf.remaining()) {
+                        dataPos = flush(out, dataBuf, dataPos);
+                    }
+
+                    // Offset of this record: everything already flushed, plus what is buffered.
+                    tableBuf.putLong(dataPos + dataBuf.position());
+                    if (!tableBuf.hasRemaining())
+                        tablePos = flush(table, tableBuf, tablePos);
+
+                    dataBuf.putInt(indices.length);
+                    for (int i = 0; i < indices.length; i++)
+                        dataBuf.putInt(indices[i]);
+                    for (int i = 0; i < values.length; i++)
+                        dataBuf.putFloat(values[i]);
+
+                    records++;
+                    if (records % PROGRESS_INTERVAL == 0)
+                        System.out.println("  ... " + records + " records, "
+                                + (dataPos + dataBuf.position()) / (1024 * 1024) + " MB");
+                }
+
+                dataPos = flush(out, dataBuf, dataPos);
+                tableBuf.putLong(dataPos); // sentinel: end of the last record
+                tablePos = flush(table, tableBuf, tablePos);
+
+                long expectedTableBytes = 8L * (records + 1);
+                if (tablePos != expectedTableBytes)
+                    throw new IOException("internal error: offset table is " + tablePos
+                            + " bytes, expected " + expectedTableBytes);
+
+                appendTable(out, tableTmp, dataPos, tablePos);
+
+                ByteBuffer header = ByteBuffer.allocate(HEADER_BYTES).order(ByteOrder.LITTLE_ENDIAN);
+                header.putLong(MAGIC);
+                header.putInt(VERSION);
+                header.putInt(0);
+                header.putLong(records);
+                header.putLong(dataPos);
+                flush(out, header, 0L);
+
+                out.force(true);
+            }
+            Files.move(tmp, Paths.get(binPath),
+                    StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+        } catch (IOException e) {
+            Files.deleteIfExists(tmp);
+            throw e;
+        } finally {
+            Files.deleteIfExists(tableTmp);
+        }
+
+        System.out.println("Sidecar built: " + binPath + " (" + records + " records"
+                + (blank > 0 ? ", " + blank + " blank" : "") + ")");
+    }
+
+    /** Copies the staged offset table onto the end of the sidecar. */
+    private static void appendTable(FileChannel out, Path tableTmp, long at, long bytes) throws IOException {
+        try (FileChannel table = FileChannel.open(tableTmp, StandardOpenOption.READ)) {
+            long remaining = bytes;
+            long target = at;
+            while (remaining > 0) {
+                long moved = out.transferFrom(table, target, remaining);
+                if (moved <= 0)
+                    throw new IOException("could not append offset table to sidecar");
+                target += moved;
+                remaining -= moved;
+            }
+        }
+    }
+
+    private static long flush(FileChannel ch, ByteBuffer buf, long position) throws IOException {
+        buf.flip();
+        long pos = position;
+        while (buf.hasRemaining())
+            pos += ch.write(buf, pos);
+        buf.clear();
+        return pos;
+    }
+
+    private static void readFully(FileChannel ch, ByteBuffer buf, long position, String what)
+            throws IOException {
+        long pos = position;
+        while (buf.hasRemaining()) {
+            int n = ch.read(buf, pos);
+            if (n < 0)
+                throw new IOException("unexpected EOF reading " + what);
+            pos += n;
+        }
+    }
+
+    /* ----------------------------------------------------- text parsing (build only) */
+
+    /**
+     * Parses one {@code "<id>\t[indices]\t[values]"} line into {@code { int[], float[] }}.
+     *
+     * <p>Runs once per record for the lifetime of the sidecar. {@code Float.parseFloat} is
+     * used deliberately: the source carries up to 17 significant digits, past the point
+     * where a hand-rolled decimal accumulator is still provably correctly rounded, and
+     * parseFloat is what makes the stored floats bit-identical to the text.
+     */
+    static Object[] parseTextRecord(String line) throws IOException {
+        int firstTab = line.indexOf('\t');
+        int secondTab = firstTab < 0 ? -1 : line.indexOf('\t', firstTab + 1);
+        if (secondTab < 0)
+            throw new IOException("Invalid .vec format: expected 3 tab-separated parts");
+
+        int indicesOpen = line.indexOf('[', firstTab + 1);
+        int indicesClose = line.lastIndexOf(']', secondTab);
+        int valuesOpen = line.indexOf('[', secondTab + 1);
+        int valuesClose = line.lastIndexOf(']');
+        if (indicesOpen < 0 || indicesClose < indicesOpen || valuesOpen < 0 || valuesClose < valuesOpen)
+            throw new IOException("Invalid .vec format: malformed index/value list");
+
+        int count = countElements(line, indicesOpen + 1, indicesClose);
+        int[] indices = new int[count];
+        float[] values = new float[count];
+        int indexCount = parseIndices(line, indicesOpen + 1, indicesClose, indices);
+        int valueCount = parseValues(line, valuesOpen + 1, valuesClose, values);
+        if (indexCount != valueCount)
+            throw new IOException("Indices and values arrays have different lengths: "
+                    + indexCount + " vs " + valueCount);
+        return new Object[] { indices, values };
+    }
+
+    /** Counts comma-separated elements in [from, to); 0 if the region is whitespace only. */
+    private static int countElements(String s, int from, int to) {
+        int i = from;
+        while (i < to && s.charAt(i) <= ' ')
+            i++;
+        if (i >= to)
+            return 0;
+        int count = 1;
+        for (; i < to; i++)
+            if (s.charAt(i) == ',')
+                count++;
+        return count;
+    }
+
+    private static int parseIndices(String s, int from, int to, int[] out) throws IOException {
+        int n = 0;
+        int i = from;
+        while (i < to) {
+            while (i < to && isSeparator(s.charAt(i)))
+                i++;
+            if (i >= to)
+                break;
+            boolean negative = s.charAt(i) == '-';
+            if (negative || s.charAt(i) == '+')
+                i++;
+            int start = i;
+            int value = 0;
+            while (i < to) {
+                char c = s.charAt(i);
+                if (c < '0' || c > '9')
+                    break;
+                value = value * 10 + (c - '0');
+                i++;
+            }
+            if (i == start)
+                throw new IOException("Invalid .vec format: malformed index at offset " + start);
+            if (n == out.length)
+                throw new IOException("Invalid .vec format: more indices than counted");
+            out[n++] = negative ? -value : value;
+        }
+        return n;
+    }
+
+    private static int parseValues(String s, int from, int to, float[] out) throws IOException {
+        int n = 0;
+        int i = from;
+        while (i < to) {
+            while (i < to && isSeparator(s.charAt(i)))
+                i++;
+            if (i >= to)
+                break;
+            int start = i;
+            while (i < to && s.charAt(i) != ',')
+                i++;
+            int end = i;
+            while (end > start && s.charAt(end - 1) <= ' ')
+                end--;
+            if (end == start)
+                throw new IOException("Invalid .vec format: empty value at offset " + start);
+            if (n == out.length)
+                throw new IOException("Invalid .vec format: more values than indices");
+            out[n++] = Float.parseFloat(s.substring(start, end));
+        }
+        return n;
+    }
+
+    private static boolean isSeparator(char c) {
+        return c == ',' || c <= ' ';
+    }
+
+    private static boolean isWhitespaceOnly(String s) {
+        for (int i = 0; i < s.length(); i++)
+            if (s.charAt(i) > ' ')
+                return false;
+        return true;
+    }
+}

--- a/src/main/java/utils/val/SparseVectorStore.java
+++ b/src/main/java/utils/val/SparseVectorStore.java
@@ -41,6 +41,7 @@ import java.nio.file.StandardOpenOption;
  *                          int  reserved    = 0
  *                          long recordCount
  *                          long tableOffset
+ *                          long sourceSize  -- size of the .vec it was built from
  *   {@value #HEADER_BYTES}  record data, records back to back
  *   tableOffset          offset table, (recordCount + 1) longs
  *                          entry[i] = absolute offset of record i
@@ -64,7 +65,10 @@ public final class SparseVectorStore implements Closeable {
     /** ASCII "MSV_SP01". */
     private static final long MAGIC = 0x4D53565F53503031L;
     private static final int VERSION = 1;
-    private static final int HEADER_BYTES = 32;
+    private static final int HEADER_BYTES = 40;
+
+    /** Overrides where the sidecar is written when the source directory is not writable. */
+    private static final String SIDECAR_DIR_PROPERTY = "msmarco.sidecar.dir";
 
     private static final String BIN_SUFFIX = ".bin";
     private static final String TMP_SUFFIX = ".tmp";
@@ -112,7 +116,7 @@ public final class SparseVectorStore implements Closeable {
      * unusable. Building is a one-off full pass over the text source.
      */
     public static SparseVectorStore open(String vecFilePath) throws IOException {
-        String path = ensureSidecar(vecFilePath);
+        String path = ensureSidecar(vecFilePath, resolveSidecarPath(vecFilePath));
         FileChannel ch = FileChannel.open(Paths.get(path), StandardOpenOption.READ);
         try {
             ByteBuffer header = ByteBuffer.allocate(HEADER_BYTES).order(ByteOrder.LITTLE_ENDIAN);
@@ -124,6 +128,7 @@ public final class SparseVectorStore implements Closeable {
             header.getInt(); // reserved
             long count = header.getLong();
             long table = header.getLong();
+            header.getLong(); // sourceSize, already validated by isUsable
 
             if (magic != MAGIC)
                 throw new IOException("Not a sparse vector sidecar: " + path);
@@ -217,16 +222,54 @@ public final class SparseVectorStore implements Closeable {
      * concurrent generators in one JVM build it once; across JVMs the build writes to a
      * temp file and renames atomically, so a racing build is wasteful but not corrupting.
      */
-    private static synchronized String ensureSidecar(String vecFilePath) throws IOException {
-        String binPath = vecFilePath + BIN_SUFFIX;
-        if (isUsable(binPath))
+    private static synchronized String ensureSidecar(String vecFilePath, String binPath) throws IOException {
+        if (isUsable(binPath, Files.size(Paths.get(vecFilePath))))
             return binPath;
         build(vecFilePath, binPath);
         return binPath;
     }
 
+    /**
+     * Picks where the sidecar lives. Next to the source is preferred so it is shared, but
+     * that directory is frequently a read-only or root-squashed export, so fall back
+     * rather than failing the load. An explicit -Dmsmarco.sidecar.dir wins over both.
+     *
+     * <p>Away from the source the file name carries a hash of the source's absolute path,
+     * so two sources with the same base name cannot collide.
+     */
+    private static String resolveSidecarPath(String vecFilePath) throws IOException {
+        Path source = Paths.get(vecFilePath).toAbsolutePath();
+        String name = source.getFileName().toString();
+
+        String configured = System.getProperty(SIDECAR_DIR_PROPERTY);
+        if (configured != null && !configured.trim().isEmpty())
+            return sidecarIn(Paths.get(configured.trim()), name, source, "-D" + SIDECAR_DIR_PROPERTY);
+
+        Path beside = source.getParent();
+        if (beside != null && Files.isWritable(beside))
+            return vecFilePath + BIN_SUFFIX;
+
+        Path working = Paths.get(System.getProperty("user.dir")).toAbsolutePath();
+        if (Files.isWritable(working)) {
+            System.out.println("Sidecar: " + beside + " is not writable, using " + working
+                    + " (set -D" + SIDECAR_DIR_PROPERTY + "=<dir> to choose another)");
+            return sidecarIn(working, name, source, "working directory");
+        }
+        throw new IOException("No writable location for the sparse vector sidecar; tried "
+                + beside + " and " + working + ". Set -D" + SIDECAR_DIR_PROPERTY + "=<dir>.");
+    }
+
+    private static String sidecarIn(Path dir, String name, Path source, String why) throws IOException {
+        if (!Files.isDirectory(dir))
+            Files.createDirectories(dir);
+        if (!Files.isWritable(dir))
+            throw new IOException("Sidecar directory " + dir + " (" + why + ") is not writable");
+        String tag = Integer.toHexString(source.toString().hashCode());
+        return dir.resolve(name + "." + tag + BIN_SUFFIX).toString();
+    }
+
     /** Cheap structural check: right magic and version, and the header agrees with the size. */
-    private static boolean isUsable(String binPath) {
+    private static boolean isUsable(String binPath, long sourceSize) {
         Path path = Paths.get(binPath);
         if (!Files.exists(path))
             return false;
@@ -241,6 +284,12 @@ public final class SparseVectorStore implements Closeable {
             header.getInt(); // reserved
             long count = header.getLong();
             long table = header.getLong();
+            long builtFrom = header.getLong();
+            if (builtFrom != sourceSize) {
+                System.out.println("Sidecar " + binPath + " was built from a " + builtFrom
+                        + " byte source but the source is now " + sourceSize + " bytes; rebuilding");
+                return false;
+            }
             return count >= 0 && table >= HEADER_BYTES && table + 8L * (count + 1) == ch.size();
         } catch (IOException e) {
             return false;
@@ -256,6 +305,7 @@ public final class SparseVectorStore implements Closeable {
         Path tmp = Paths.get(binPath + TMP_SUFFIX);
         Path tableTmp = Paths.get(binPath + TABLE_TMP_SUFFIX);
 
+        long sourceSize = Files.size(Paths.get(vecFilePath));
         System.out.println("Building sparse vector sidecar: " + vecFilePath + " -> " + binPath);
         System.out.println("  one-off; subsequent loads read it directly and do no text parsing");
 
@@ -333,6 +383,7 @@ public final class SparseVectorStore implements Closeable {
                 header.putInt(0);
                 header.putLong(records);
                 header.putLong(dataPos);
+                header.putLong(sourceSize);
                 flush(out, header, 0L);
 
                 out.force(true);

--- a/src/main/java/utils/val/SparseVectorStore.java
+++ b/src/main/java/utils/val/SparseVectorStore.java
@@ -77,8 +77,9 @@ public final class SparseVectorStore implements Closeable {
     private static final int VERSION = 1;
     private static final int HEADER_BYTES = 40;
 
-    /** Overrides where the sidecar is written when the source directory is not writable. */
+    /** Overrides where the sidecar lives when the source directory is not writable. */
     private static final String SIDECAR_DIR_PROPERTY = "msmarco.sidecar.dir";
+    private static final String SIDECAR_DIR_ENV = "MSMARCO_SIDECAR_DIR";
 
     private static final String BIN_SUFFIX = ".bin";
     private static final String TMP_SUFFIX = ".tmp";
@@ -133,8 +134,8 @@ public final class SparseVectorStore implements Closeable {
         if (!isUsable(path, Files.size(Paths.get(vecFilePath)))) {
             if (ANNOUNCED.compareAndSet(false, true))
                 System.out.println("No sparse vector sidecar at " + path
-                        + "; reading the text source. Build one with:  java -cp <jar> "
-                        + SparseVectorStore.class.getName() + " " + vecFilePath);
+                        + "; reading the text source. Build one with:  java " + whereHint()
+                        + " -cp <jar> " + SparseVectorStore.class.getName() + " " + vecFilePath);
             return null;
         }
         FileChannel ch = FileChannel.open(Paths.get(path), StandardOpenOption.READ);
@@ -194,8 +195,11 @@ public final class SparseVectorStore implements Closeable {
         long from = offsetPair.getLong(0);
         long to = offsetPair.getLong(8);
 
+        // Bounded against MAX_NNZ here, not just against Integer.MAX_VALUE. The nnz field
+        // is the real check, but it can only be read after the record is in memory, so a
+        // corrupt table entry would first size the buffer below to whatever it claimed.
         long span = to - from;
-        if (span < 4 || span > Integer.MAX_VALUE)
+        if (span < 4 || span > 4L + 8L * MAX_NNZ)
             throw new IOException("corrupt record length " + span + " at record " + recordIndex
                     + " in " + binPath);
 
@@ -238,7 +242,7 @@ public final class SparseVectorStore implements Closeable {
     /* ---------------------------------------------------------------- build */
 
     /**
-     * Where the sidecar for this source lives: an explicit -Dmsmarco.sidecar.dir if set,
+     * Where the sidecar for this source lives: the configured directory if there is one,
      * otherwise beside the source.
      *
      * <p>Deliberately not derived from the working directory. Doing so made the location
@@ -250,13 +254,37 @@ public final class SparseVectorStore implements Closeable {
      */
     static String sidecarPath(String vecFilePath) {
         Path source = Paths.get(vecFilePath).toAbsolutePath();
-        String configured = System.getProperty(SIDECAR_DIR_PROPERTY);
-        if (configured != null && !configured.trim().isEmpty())
-            return Paths.get(configured.trim())
+        String configured = configuredDir();
+        if (configured != null)
+            return Paths.get(configured)
                     .resolve(source.getFileName() + "."
                             + Integer.toHexString(source.toString().hashCode()) + BIN_SUFFIX)
                     .toString();
         return vecFilePath + BIN_SUFFIX;
+    }
+
+    /**
+     * -Dmsmarco.sidecar.dir if set, else $MSMARCO_SIDECAR_DIR, else null for "beside the
+     * source".
+     *
+     * <p>The environment variable is honoured because "beside the source" is not always a
+     * location that can hold a sidecar, and the JVM that needs to read one is not always
+     * ours to add flags to. On the volume hosts the .vec sits on a read-only NFS export,
+     * and the REST server is started by the test framework from a fixed argument list with
+     * no -D in it -- so a system property alone leaves the sidecar unreachable from the
+     * only process that would benefit. An exported variable is inherited by both the
+     * server and the CLI builder, which keeps them pointed at one file.
+     */
+    private static String configuredDir() {
+        String dir = System.getProperty(SIDECAR_DIR_PROPERTY);
+        if (dir == null || dir.trim().isEmpty())
+            dir = System.getenv(SIDECAR_DIR_ENV);
+        return dir == null || dir.trim().isEmpty() ? null : dir.trim();
+    }
+
+    /** How to point both the builder and the server at a writable directory. */
+    private static String whereHint() {
+        return "-D" + SIDECAR_DIR_PROPERTY + "=<dir> (or export " + SIDECAR_DIR_ENV + "=<dir>)";
     }
 
     /**
@@ -269,8 +297,8 @@ public final class SparseVectorStore implements Closeable {
         if (dir != null && !Files.isDirectory(dir))
             Files.createDirectories(dir);
         if (dir != null && !Files.isWritable(dir))
-            throw new IOException("Sidecar directory " + dir + " is not writable. Set -D"
-                    + SIDECAR_DIR_PROPERTY + "=<dir> to choose a writable one.");
+            throw new IOException("Sidecar directory " + dir + " is not writable. Set "
+                    + whereHint() + " to choose a writable one.");
         if (Thread.currentThread().isInterrupted())
             throw new IOException("Refusing to build: this thread is already interrupted, and"
                     + " channel writes would fail immediately.");
@@ -281,8 +309,8 @@ public final class SparseVectorStore implements Closeable {
     public static void main(String[] args) throws Exception {
         if (args.length != 1) {
             System.err.println("usage: " + SparseVectorStore.class.getName() + " <path-to-.vec>");
-            System.err.println("       -D" + SIDECAR_DIR_PROPERTY
-                    + "=<dir> to place the sidecar somewhere other than beside the source");
+            System.err.println("       " + whereHint()
+                    + " to place the sidecar somewhere other than beside the source");
             System.exit(2);
         }
         long started = System.currentTimeMillis();
@@ -314,7 +342,8 @@ public final class SparseVectorStore implements Closeable {
             long builtFrom = header.getLong();
             if (builtFrom != sourceSize) {
                 System.out.println("Sidecar " + binPath + " was built from a " + builtFrom
-                        + " byte source but the source is now " + sourceSize + " bytes; rebuilding");
+                        + " byte source but the source is now " + sourceSize
+                        + " bytes; ignoring it and reading the text source");
                 return false;
             }
             return count >= 0 && table >= HEADER_BYTES && table + 8L * (count + 1) == ch.size();
@@ -344,6 +373,11 @@ public final class SparseVectorStore implements Closeable {
         ByteBuffer dataBuf = ByteBuffer.allocate(DATA_WRITE_BUFFER).order(ByteOrder.LITTLE_ENDIAN);
         ByteBuffer tableBuf = ByteBuffer.allocate(8 * TABLE_WRITE_ENTRIES).order(ByteOrder.LITTLE_ENDIAN);
 
+        // Cleared only once the rename lands. A flag rather than a catch clause because
+        // the build can fail unchecked -- a malformed line reaches Float.parseFloat as a
+        // NumberFormatException -- and the partial data file here is on the order of the
+        // 13GB the finished one would be, which is not something to strand on the disk.
+        boolean renamed = false;
         try {
             try (FileChannel out = FileChannel.open(tmp, StandardOpenOption.CREATE,
                             StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
@@ -417,11 +451,11 @@ public final class SparseVectorStore implements Closeable {
             }
             Files.move(tmp, Paths.get(binPath),
                     StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
-        } catch (IOException e) {
-            Files.deleteIfExists(tmp);
-            throw e;
+            renamed = true;
         } finally {
             Files.deleteIfExists(tableTmp);
+            if (!renamed)
+                Files.deleteIfExists(tmp);
         }
 
         System.out.println("Sidecar built: " + binPath + " (" + records + " records"


### PR DESCRIPTION
Loads the MSMARCO sparse corpus **2.9x faster** (601s -> 211s for 8,841,823 documents)
by parsing the `.vec` source once into a binary sidecar instead of re-parsing 47.5GB of
text on every run. Stored documents are unchanged, byte for byte.

## Root cause

`Float.parseFloat` was the single largest cost in this loader, in both CPU and allocation.

The `.vec` source prints values at up to 17 significant digits
(`0.046767983585596085`). That is past the fast path in
`FloatingDecimal.readJavaFormatString`, so every value falls into the
arbitrary-precision correction loop backed by `sun.misc.FDBigInteger`. A live heap
histogram taken during a load:

```
   1:      11723980      928324864  [C
   2:      17284080      757324368  [I
   3:      11750639      376020448  sun.misc.FDBigInteger
   5:       3613619      115635808  sun.misc.FloatingDecimal$ASCIIToBinaryBuffer
```

~1.19GB of pure parser scratch, live at one instant. At ~200 values per record over
8.8M records this dominates everything else the loader does, and the resulting
allocation rate is what drove ParallelGC's adaptive sizing to inflate eden to 2.58GB
chasing its `GCTimeRatio=99` goal.

This cost is inherent to the text format; it is not introduced by any recent change.

## What changed

New `SparseVectorStore` owns a binary sidecar format and is shared by both product
classes, so the layout is defined once instead of duplicated the way the parser was.

```
header (40B):  magic, version, reserved, recordCount, tableOffset, sourceSize
record data:   per record - int nnz, int[nnz] indices, float[nnz] values
offset table:  recordCount+1 absolute offsets, trailing sentinel
```

Design points:

- **Table after the data**, so the build needs no advance record count and has no
  dependency on the old `.idx` (which is now unused).
- **Offsets read positionally**, one entry at a time. Holding the table for an
  8.8M-record source would be a ~70MB `long[]` per generator instance.
- **Direct `ByteBuffer`s.** `FileChannel.read()` into a *heap* buffer copies through a
  temporary direct buffer it allocates itself, which measured ~1.1KB of churn per
  record. One 16-byte read fetches both bounding offsets.
- **Sidecar location resolves**: `-Dmsmarco.sidecar.dir` -> beside the source -> working
  directory. Beside the source is preferred, but that is frequently a read-only or
  root-squashed NFS export, and failing the load there is not acceptable.
- **`sourceSize` in the header** is checked on open, so a sidecar built from a changed
  or different `.vec` is rebuilt rather than silently reused.

Both product classes lose all file, index and text-parsing machinery and simply address
records by index.

## Size diff

**Code** - 3 files, net +284 lines, but the two product classes shrink substantially and
the duplicated parser between them is gone:

```
 src/main/java/utils/val/MSMARCOEmbeddingProduct.java      | 262 +---------
 src/main/java/utils/val/MSMARCOSiftEmbeddingProduct.java  | 267 +---------
 src/main/java/utils/val/SparseVectorStore.java            | 549 +++++++++++++++++++++
 3 files changed, 604 insertions(+), 320 deletions(-)
```

**On disk** - the sidecar is 3.44x smaller than the text it replaces:

| File | Size |
|---|---|
| `collection.vecs` (source, still required) | 47,561,813,179 B (44.3 GiB) |
| `collection.vecs.bin` (sidecar) | 13,829,919,980 B (12.9 GiB) |
| `collection.vecs.idx` (no longer used) | 70,734,592 B |

**Per-record allocation**, measured with `ThreadMXBean.getThreadAllocatedBytes` over
20,000 records on both paths:

| Path | Allocation per record |
|---|---|
| Text parse (before) | 72,700 B |
| Sidecar read (after) | 2,285 B |
| | **31.8x less, ~70KB of garbage removed per document** |

What remains is essentially just the `int[]`/`float[]` the document actually carries.

## Test results

Full corpus, `-cr 100 -create_s 0 -create_e 8841823 -w 20 -ops 50000`, each variant into
its own fresh collection on a 6-node cluster. Two replicates in **reversed order** to
control for run-order effects. All four runs completed 60/60 tasks and loaded exactly
8,841,823 documents with **zero exceptions**.

| Run | Variant | Position | Load time | Peak RSS |
|---|---|---|---|---|
| 1 | base | 1st | 546 s | 3.047 GiB |
| 2 | change | 2nd | **205 s** | 2.988 GiB |
| 3 | change | 1st | **216 s** | 2.962 GiB |
| 4 | base | 2nd | 657 s | 3.089 GiB |

| Metric | base (mean) | change (mean) | Delta |
|---|---|---|---|
| **Load time** | **601.5 s** | **210.5 s** | **-65%, 2.86x faster** |
| **Throughput** | 14,700 docs/s | 42,004 docs/s | **+186%** |
| Peak RSS | 3.068 GiB | 2.975 GiB | -3.0% |

```
Load time (seconds, lower is better)
base    601.5  ############################################################
change  210.5  #####################

Throughput (docs/sec, higher is better)
base    14,700 #####################
change  42,004 ############################################################
```

The result holds in **both orderings**, so it is not a run-order artifact:

- Same 1st position: base 546 s vs change 216 s -> 2.53x
- Same 2nd position: base 657 s vs change 205 s -> 3.20x

**The headline is throughput, not RSS.** `base` achieved only 14.7k docs/s against the
requested `-ops 50000` - it was client-side CPU-bound on `Float.parseFloat`. `change`
reaches 42k docs/s, close to the target, so the loader is no longer the bottleneck.

RSS moves only ~3% because peak RSS is set by the heap ParallelGC has already committed,
and JDK 8 ParallelGC does not return committed pages (`MaxHeapFreeRatio` defaults to 100
for this collector, and an idle JVM runs no GC to reconsider sizing). Bounding RSS
requires `-Xmx`; this change removes the allocation pressure that made a large heap
necessary, so a low `-Xmx` should now cost very little in GC overhead.

## Correctness

Verified against the pre-change build:

- Every record of a 2,000-record sample, **388,511 non-zeros, compared bit for bit** via
  `Float.floatToRawIntBits`: **0 mismatches**
- Generated documents byte-identical at full scale - record 0, record 1,000,000 (a
  different STEPS range) and `-base64` - md5 `5cc634b8`, `7cc50b2b`, `0ea63329`
- `MSMARCOSiftEmbeddingProduct` documents byte-identical, plain and `-base64`
- Mutation mode byte-identical at `mutated` = 1, 7, 250
- Last record reads; one past the end is rejected
- Sidecar reused without rebuild; corrupt header, truncation and source-size change each
  detected and rebuilt; no temp files left behind

Values are bit-exact by construction: the sidecar stores the `float` that
`Float.parseFloat` already produced.

## Operational notes

- **First run builds the sidecar**: a one-off full pass over the source, on the order of
  ten minutes for 47.5GB, needing ~12.9GiB of disk. Progress is logged every million
  records. Subsequent opens are instant.
- **Choose the location with `-Dmsmarco.sidecar.dir=<dir>`** if the source directory is
  not writable, or if the default working directory is unsuitable. On the volume-test
  host `/mnt/nfsdata` is root-squashed and the working directory is on tmpfs, so this
  needs to be set explicitly there.
- The old `.idx` sidecar is no longer read and can be deleted.

## Not addressed

- No `-Xmx` is set anywhere; the JVM still defaults to 1/4 of RAM. That remains the
  direct lever for RSS and is complementary to this change.
- The batch-size cap in `WorkLoadSettings` is still computed from an unrepresentative
  `-docSize` default for this loader.

## Commits

```
ec75f8c  Read .vec offsets positionally instead of holding a 70MB long[] per generator
e2482f0  Parse .vec records into int[]/float[] instead of boxed List<Integer>/List<Float>
079eb81  Read sparse vectors from a binary sidecar instead of parsing text on every load
a9e14fa  Fall back to a writable directory when the source directory rejects the sidecar
```
