### PR TITLE
Fix/bulk op batch isolation

### DIFF
--- a/src/main/java/couchbase/loadgen/WorkLoadGenerate.java
+++ b/src/main/java/couchbase/loadgen/WorkLoadGenerate.java
@@ -257,18 +257,26 @@ public class WorkLoadGenerate extends Task{
                     if(this.dg.ws.elastic) {
                         this.esClient.insertDocs(this.collection.replace("_", ""), docs);
                     }
-                    List<Result> result = new ArrayList<Result>();
-                    if(this.sdk != null)
-                        result = docops.bulkInsert(this.sdk.connection, docs, setOptions);
                     ops += dg.ws.batchSize*dg.ws.creates/100;
-                    this.completedOps.addAndGet(docs.size());
-                    if(this.trackFailures && result.size()>0){
-                        this.result = false;
-                        try {
-                            failedMutations.get("create").addAll(result);
-                        } catch (Exception e) {
-                            failedMutations.put("create", result);
+                    try {
+                        List<Result> result = new ArrayList<Result>();
+                        if(this.sdk != null)
+                            result = docops.bulkInsert(this.sdk.connection, docs, setOptions);
+                        this.completedOps.addAndGet(docs.size());
+                        if(this.trackFailures && result.size()>0){
+                            this.result = false;
+                            try {
+                                failedMutations.get("create").addAll(result);
+                            } catch (Exception e) {
+                                failedMutations.put("create", result);
+                            }
                         }
+                    } catch (Exception e) {
+                        // Aggregate block() failed (e.g. BULK_OP_TIMEOUT) for this batch alone -
+                        // do not let it kill the whole task; record and keep looping so stop_load
+                        // is re-checked next iteration instead of being stuck here indefinitely.
+                        logger.error(this.taskName + ": bulkInsert (create) batch failed: " + e.toString(), e);
+                        this.result = false;
                     }
                 }
             }
@@ -279,18 +287,23 @@ public class WorkLoadGenerate extends Task{
                     if(this.dg.ws.elastic) {
                         this.esClient.insertDocs(this.collection.replace("_", ""), docs);
                     }
-                    List<Result> result = new ArrayList<Result>();
-                    if(this.sdk != null)
-                        result = docops.bulkUpsert(this.sdk.connection, docs, upsertOptions);
                     ops += dg.ws.batchSize*dg.ws.updates/100;
-                    this.completedOps.addAndGet(docs.size());
-                    if(this.trackFailures && result.size()>0){
-                        this.result = false;
-                        try {
-                            failedMutations.get("update").addAll(result);
-                        } catch (Exception e) {
-                            failedMutations.put("update", result);
+                    try {
+                        List<Result> result = new ArrayList<Result>();
+                        if(this.sdk != null)
+                            result = docops.bulkUpsert(this.sdk.connection, docs, upsertOptions);
+                        this.completedOps.addAndGet(docs.size());
+                        if(this.trackFailures && result.size()>0){
+                            this.result = false;
+                            try {
+                                failedMutations.get("update").addAll(result);
+                            } catch (Exception e) {
+                                failedMutations.put("update", result);
+                            }
                         }
+                    } catch (Exception e) {
+                        logger.error(this.taskName + ": bulkUpsert (update) batch failed: " + e.toString(), e);
+                        this.result = false;
                     }
                 }
             }
@@ -298,18 +311,23 @@ public class WorkLoadGenerate extends Task{
                 List<Tuple2<String, Object>> docs = dg.nextExpiryBatch();
                 if (docs.size()>0) {
                     flag = true;
-                    List<Result> result = new ArrayList<Result>();
-                    if(this.sdk != null)
-                        result = docops.bulkInsert(this.sdk.connection, docs, expiryOptions);
                     ops += dg.ws.batchSize*dg.ws.expiry/100;
-                    this.completedOps.addAndGet(docs.size());
-                    if(this.trackFailures && result.size()>0){
-                        this.result = false;
-                        try {
-                            failedMutations.get("expiry").addAll(result);
-                        } catch (Exception e) {
-                            failedMutations.put("expiry", result);
+                    try {
+                        List<Result> result = new ArrayList<Result>();
+                        if(this.sdk != null)
+                            result = docops.bulkInsert(this.sdk.connection, docs, expiryOptions);
+                        this.completedOps.addAndGet(docs.size());
+                        if(this.trackFailures && result.size()>0){
+                            this.result = false;
+                            try {
+                                failedMutations.get("expiry").addAll(result);
+                            } catch (Exception e) {
+                                failedMutations.put("expiry", result);
+                            }
                         }
+                    } catch (Exception e) {
+                        logger.error(this.taskName + ": bulkInsert (expiry) batch failed: " + e.toString(), e);
+                        this.result = false;
                     }
                 }
             }
@@ -317,21 +335,26 @@ public class WorkLoadGenerate extends Task{
                 List<String> docs = dg.nextDeleteBatch();
                 if (docs.size()>0) {
                     flag = true;
-                    List<Result> result = new ArrayList<Result>();
-                    if(this.sdk != null)
-                        result = docops.bulkDelete(this.sdk.connection, docs, removeOptions);
-                    if(this.dg.ws.elastic) {
-                        this.esClient.deleteDocs(this.collection.replace("_", ""), docs);
-                    }
                     ops += dg.ws.batchSize*dg.ws.deletes/100;
-                    this.completedOps.addAndGet(docs.size());
-                    if(this.trackFailures && result.size()>0){
-                        this.result = false;
-                        try {
-                            failedMutations.get("delete").addAll(result);
-                        } catch (Exception e) {
-                            failedMutations.put("delete", result);
+                    try {
+                        List<Result> result = new ArrayList<Result>();
+                        if(this.sdk != null)
+                            result = docops.bulkDelete(this.sdk.connection, docs, removeOptions);
+                        if(this.dg.ws.elastic) {
+                            this.esClient.deleteDocs(this.collection.replace("_", ""), docs);
                         }
+                        this.completedOps.addAndGet(docs.size());
+                        if(this.trackFailures && result.size()>0){
+                            this.result = false;
+                            try {
+                                failedMutations.get("delete").addAll(result);
+                            } catch (Exception e) {
+                                failedMutations.put("delete", result);
+                            }
+                        }
+                    } catch (Exception e) {
+                        logger.error(this.taskName + ": bulkDelete batch failed: " + e.toString(), e);
+                        this.result = false;
                     }
                 }
             }
@@ -339,38 +362,43 @@ public class WorkLoadGenerate extends Task{
                 List<Tuple2<String, Object>> docs = dg.nextReadBatch();
                 if (docs.size()>0) {
                     flag = true;
-                    List<Tuple2<String, Object>> res = docops.bulkGets(this.sdk.connection, docs, getOptions);
-                    if (this.dg.ws.validate) {
-                        Map<Object, Object> trnx_res = res.stream().collect(Collectors.toMap(t -> t.get(0), t -> t.get(1)));
-                        Map<Object, Object> trnx_docs = docs.stream().collect(Collectors.toMap(t -> t.get(0), t -> t.get(1)));
-                        ObjectMapper om = new ObjectMapper();
-                        om.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
-                        for (Object name : trnx_docs.keySet()) {
-                            try {
-                                String a = om.writeValueAsString(trnx_res.get(name));
-                                String b = om.writeValueAsString(trnx_docs.get(name));
-                                if(this.dg.ws.expectDeleted) {
-                                    if(!a.contains(DocumentNotFoundException.class.getSimpleName())) {
+                    ops += dg.ws.batchSize*dg.ws.reads/100;
+                    try {
+                        List<Tuple2<String, Object>> res = docops.bulkGets(this.sdk.connection, docs, getOptions);
+                        if (this.dg.ws.validate) {
+                            Map<Object, Object> trnx_res = res.stream().collect(Collectors.toMap(t -> t.get(0), t -> t.get(1)));
+                            Map<Object, Object> trnx_docs = docs.stream().collect(Collectors.toMap(t -> t.get(0), t -> t.get(1)));
+                            ObjectMapper om = new ObjectMapper();
+                            om.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
+                            for (Object name : trnx_docs.keySet()) {
+                                try {
+                                    String a = om.writeValueAsString(trnx_res.get(name));
+                                    String b = om.writeValueAsString(trnx_docs.get(name));
+                                    if(this.dg.ws.expectDeleted) {
+                                        if(!a.contains(DocumentNotFoundException.class.getSimpleName())) {
+                                            System.out.println("Validation failed for key: " + this.sdk.scope + ":" + this.sdk.collection + ":" + name);
+                                            System.out.println("Actual Value - " + a);
+                                            System.out.println("Expected Value - " + b);
+                                            System.out.println(this.taskName + " is completed!");
+                                            return;
+                                        }
+                                    } else if(!a.equals(b) && !a.contains("TimeoutException")){
                                         System.out.println("Validation failed for key: " + this.sdk.scope + ":" + this.sdk.collection + ":" + name);
                                         System.out.println("Actual Value - " + a);
                                         System.out.println("Expected Value - " + b);
                                         System.out.println(this.taskName + " is completed!");
                                         return;
                                     }
-                                } else if(!a.equals(b) && !a.contains("TimeoutException")){
-                                    System.out.println("Validation failed for key: " + this.sdk.scope + ":" + this.sdk.collection + ":" + name);
-                                    System.out.println("Actual Value - " + a);
-                                    System.out.println("Expected Value - " + b);
-                                    System.out.println(this.taskName + " is completed!");
-                                    return;
+                                } catch (JsonProcessingException e) {
+                                    e.printStackTrace();
                                 }
-                            } catch (JsonProcessingException e) {
-                                e.printStackTrace();
                             }
                         }
+                        this.completedOps.addAndGet(docs.size());
+                    } catch (Exception e) {
+                        logger.error(this.taskName + ": bulkGets (read) batch failed: " + e.toString(), e);
+                        this.result = false;
                     }
-                    ops += dg.ws.batchSize*dg.ws.reads/100;
-                    this.completedOps.addAndGet(docs.size());
                 }
             }
             if(dg.ws.subdocs> 0) {

--- a/src/main/java/couchbase/loadgen/WorkLoadGenerate.java
+++ b/src/main/java/couchbase/loadgen/WorkLoadGenerate.java
@@ -277,6 +277,12 @@ public class WorkLoadGenerate extends Task{
                         // is re-checked next iteration instead of being stuck here indefinitely.
                         logger.error(this.taskName + ": bulkInsert (create) batch failed: " + e.toString(), e);
                         this.result = false;
+                        // A real cancel_task() interrupt must still end the task - do not swallow it
+                        // and retry, or hard cancellation becomes as ineffective as stop_task() is.
+                        if (Thread.currentThread().isInterrupted()) {
+                            logger.error(this.taskName + ": interrupted, stopping");
+                            return;
+                        }
                     }
                 }
             }
@@ -304,6 +310,10 @@ public class WorkLoadGenerate extends Task{
                     } catch (Exception e) {
                         logger.error(this.taskName + ": bulkUpsert (update) batch failed: " + e.toString(), e);
                         this.result = false;
+                        if (Thread.currentThread().isInterrupted()) {
+                            logger.error(this.taskName + ": interrupted, stopping");
+                            return;
+                        }
                     }
                 }
             }
@@ -328,6 +338,10 @@ public class WorkLoadGenerate extends Task{
                     } catch (Exception e) {
                         logger.error(this.taskName + ": bulkInsert (expiry) batch failed: " + e.toString(), e);
                         this.result = false;
+                        if (Thread.currentThread().isInterrupted()) {
+                            logger.error(this.taskName + ": interrupted, stopping");
+                            return;
+                        }
                     }
                 }
             }
@@ -355,6 +369,10 @@ public class WorkLoadGenerate extends Task{
                     } catch (Exception e) {
                         logger.error(this.taskName + ": bulkDelete batch failed: " + e.toString(), e);
                         this.result = false;
+                        if (Thread.currentThread().isInterrupted()) {
+                            logger.error(this.taskName + ": interrupted, stopping");
+                            return;
+                        }
                     }
                 }
             }
@@ -398,6 +416,10 @@ public class WorkLoadGenerate extends Task{
                     } catch (Exception e) {
                         logger.error(this.taskName + ": bulkGets (read) batch failed: " + e.toString(), e);
                         this.result = false;
+                        if (Thread.currentThread().isInterrupted()) {
+                            logger.error(this.taskName + ": interrupted, stopping");
+                            return;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Problem

Jenkins jobs using sirius_java_sdk doc loading were hanging for hours and only ever ending via the 12-hour Jenkins timeout — never recovering or failing cleanly on their own.

Root cause: each op-type block (create/update/expiry/delete/read) in WorkLoadGenerate.actual_run() called docops.bulkX(...) — which wraps an aggregate .timeout(BULK_OP_TIMEOUT=120s).block() in DocOps.java — with no try/catch. If that call ever threw (the 120s timeout firing, or any other exception), it propagated straight out of the while loop to run()'s outer catch, which logged it and returned — permanently ending that task's thread. No further batches ever ran, and completedOps froze forever.

This made recovery impossible even when the framework tried:

stop_task() only sets a cooperative flag the loop checks between batches — with the thread dead/stuck, it was never checked again.
get_task_result()'s future.get() blocks with no timeout, so it could also hang indefinitely alongside the stuck task.

Confirmed directly against a real job's sirius_run.log: the task's own periodic status print stopped mid-run while Couchbase SDK diagnostics showed individual inserts repeatedly hitting their 60s client-side timeout (OverThresholdRequestsRecordedEvent, total_duration_us ≈ 60,013,325) — consistent with sustained backpressure eventually pushing a batch's aggregate past the 120s backstop.

Fix
Wrap each op-type's docops.bulkX(...) call in try/catch: log the failure, mark result = false, and let the loop continue to the next batch instead of dying.
ops (the loop's own "did work happen this iteration" signal, used by if(ops==0) break) is now incremented unconditionally whenever a batch was attempted — only completedOps/failedMutations stay conditional on the call actually succeeding.
Explicitly check Thread.currentThread().isInterrupted() after each catch and return immediately if set, so a genuine cancel_task() hard-interrupt still ends the task instead of being swallowed and retried like a normal transient failure.