### PR TITLE
Bind loader collections per call instead of on the shared SDK client

### DIFF
--- a/src/main/java/RestServer/TaskRequest.java
+++ b/src/main/java/RestServer/TaskRequest.java
@@ -623,6 +623,9 @@ public class TaskRequest {
             body.put("active_tasks", TaskRequest.taskManager.getActiveTaskCount());
             body.put("queued_tasks", TaskRequest.taskManager.getQueuedTaskCount());
             body.put("pool_workers", TaskRequest.taskManager.getWorkerCount());
+            // False while the task is still queued for a thread. A caller watching for
+            // a stall must not run its clock on a task the pool has never started.
+            body.put("has_started", task.started);
             body.put("status", true);
         } else {
             body.put("error", "Task " + this.taskName + " does not exists");

--- a/src/main/java/couchbase/loadgen/WorkLoadGenerate.java
+++ b/src/main/java/couchbase/loadgen/WorkLoadGenerate.java
@@ -500,6 +500,14 @@ public class WorkLoadGenerate extends Task{
      * collection (the CLI loaders) already knows its own.
      */
     private Collection targetCollection() {
+        if (this.sdk == null) {
+            // A load with no KV client (Elasticsearch-only). The four bulk mutation
+            // sites guard on sdk != null and skip the KV call, so they never touch
+            // this; reads/subdocs/retry do not guard and would have failed on a null
+            // client before this change too. Resolving eagerly must not break the
+            // mutation path that did tolerate it.
+            return null;
+        }
         if (this.sdkClientPool != null) {
             return this.sdk.collection(this.scope, this.collection);
         }

--- a/src/main/java/couchbase/loadgen/WorkLoadGenerate.java
+++ b/src/main/java/couchbase/loadgen/WorkLoadGenerate.java
@@ -22,6 +22,7 @@ import com.couchbase.client.core.error.DocumentExistsException;
 import com.couchbase.client.core.error.DocumentNotFoundException;
 import com.couchbase.client.core.error.ServerOutOfMemoryException;
 import com.couchbase.client.core.error.TimeoutException;
+import com.couchbase.client.java.Collection;
 import com.couchbase.client.java.kv.GetOptions;
 import com.couchbase.client.java.kv.InsertOptions;
 import com.couchbase.client.java.kv.RemoveOptions;
@@ -174,6 +175,10 @@ public class WorkLoadGenerate extends Task{
     public void actual_run() {
         this.result = true;
         logger.info("Starting " + this.taskName);
+        // Resolved once into a local. Never stored on the shared SDKClient: this worker
+        // must keep writing to its own collection even though other workers are using
+        // the same client for theirs.
+        final Collection target = this.targetCollection();
         // Set timeout in WorkLoadSettings
         this.dg.ws.setTimeoutDuration(60, "seconds");
         // Set Durability in WorkLoadSettings
@@ -259,7 +264,7 @@ public class WorkLoadGenerate extends Task{
                     }
                     List<Result> result = new ArrayList<Result>();
                     if(this.sdk != null)
-                        result = docops.bulkInsert(this.sdk.connection, docs, setOptions);
+                        result = docops.bulkInsert(target, docs, setOptions);
                     ops += dg.ws.batchSize*dg.ws.creates/100;
                     this.completedOps.addAndGet(docs.size());
                     if(this.trackFailures && result.size()>0){
@@ -281,7 +286,7 @@ public class WorkLoadGenerate extends Task{
                     }
                     List<Result> result = new ArrayList<Result>();
                     if(this.sdk != null)
-                        result = docops.bulkUpsert(this.sdk.connection, docs, upsertOptions);
+                        result = docops.bulkUpsert(target, docs, upsertOptions);
                     ops += dg.ws.batchSize*dg.ws.updates/100;
                     this.completedOps.addAndGet(docs.size());
                     if(this.trackFailures && result.size()>0){
@@ -300,7 +305,7 @@ public class WorkLoadGenerate extends Task{
                     flag = true;
                     List<Result> result = new ArrayList<Result>();
                     if(this.sdk != null)
-                        result = docops.bulkInsert(this.sdk.connection, docs, expiryOptions);
+                        result = docops.bulkInsert(target, docs, expiryOptions);
                     ops += dg.ws.batchSize*dg.ws.expiry/100;
                     this.completedOps.addAndGet(docs.size());
                     if(this.trackFailures && result.size()>0){
@@ -319,7 +324,7 @@ public class WorkLoadGenerate extends Task{
                     flag = true;
                     List<Result> result = new ArrayList<Result>();
                     if(this.sdk != null)
-                        result = docops.bulkDelete(this.sdk.connection, docs, removeOptions);
+                        result = docops.bulkDelete(target, docs, removeOptions);
                     if(this.dg.ws.elastic) {
                         this.esClient.deleteDocs(this.collection.replace("_", ""), docs);
                     }
@@ -339,7 +344,7 @@ public class WorkLoadGenerate extends Task{
                 List<Tuple2<String, Object>> docs = dg.nextReadBatch();
                 if (docs.size()>0) {
                     flag = true;
-                    List<Tuple2<String, Object>> res = docops.bulkGets(this.sdk.connection, docs, getOptions);
+                    List<Tuple2<String, Object>> res = docops.bulkGets(target, docs, getOptions);
                     if (this.dg.ws.validate) {
                         Map<Object, Object> trnx_res = res.stream().collect(Collectors.toMap(t -> t.get(0), t -> t.get(1)));
                         Map<Object, Object> trnx_docs = docs.stream().collect(Collectors.toMap(t -> t.get(0), t -> t.get(1)));
@@ -351,14 +356,14 @@ public class WorkLoadGenerate extends Task{
                                 String b = om.writeValueAsString(trnx_docs.get(name));
                                 if(this.dg.ws.expectDeleted) {
                                     if(!a.contains(DocumentNotFoundException.class.getSimpleName())) {
-                                        System.out.println("Validation failed for key: " + this.sdk.scope + ":" + this.sdk.collection + ":" + name);
+                                        System.out.println("Validation failed for key: " + this.scope + ":" + this.collection + ":" + name);
                                         System.out.println("Actual Value - " + a);
                                         System.out.println("Expected Value - " + b);
                                         System.out.println(this.taskName + " is completed!");
                                         return;
                                     }
                                 } else if(!a.equals(b) && !a.contains("TimeoutException")){
-                                    System.out.println("Validation failed for key: " + this.sdk.scope + ":" + this.sdk.collection + ":" + name);
+                                    System.out.println("Validation failed for key: " + this.scope + ":" + this.collection + ":" + name);
                                     System.out.println("Actual Value - " + a);
                                     System.out.println("Expected Value - " + b);
                                     System.out.println(this.taskName + " is completed!");
@@ -379,7 +384,7 @@ public class WorkLoadGenerate extends Task{
                 docs = dg.nextSubDocBatch("insert");
                 if (docs.size()>0) {
                     flag = true;
-                    List<HashMap<String,Object>> result = subDocOps.bulkSubDocOperation(this.sdk.connection, docs, mutateInOptions);
+                    List<HashMap<String,Object>> result = subDocOps.bulkSubDocOperation(target, docs, mutateInOptions);
                     ops += dg.ws.batchSize*dg.ws.subdocs/100;
                     this.completedOps.addAndGet(docs.size());
                     this.update_subdoc_failed_mutation_result("insert", failedMutations, result);
@@ -388,7 +393,7 @@ public class WorkLoadGenerate extends Task{
                 docs = dg.nextSubDocBatch("upsert");
                 if (docs.size()>0) {
                     flag = true;
-                    List<HashMap<String,Object>> result = subDocOps.bulkSubDocOperation(this.sdk.connection, docs, mutateInOptions);
+                    List<HashMap<String,Object>> result = subDocOps.bulkSubDocOperation(target, docs, mutateInOptions);
                     ops += dg.ws.batchSize*dg.ws.subdocs/100;
                     this.completedOps.addAndGet(docs.size());
                     this.update_subdoc_failed_mutation_result("upsert", failedMutations, result);
@@ -397,7 +402,7 @@ public class WorkLoadGenerate extends Task{
                 List<Tuple2<String,List<LookupInSpec>>> lookup_docs = dg.nextSubDocLookupBatch();
                 if (lookup_docs.size()>0) {
                     flag = true;
-                    List<HashMap<String,Object>> result = subDocOps.bulkGetSubDocOperation(this.sdk.connection, lookup_docs, lookupInOptions);
+                    List<HashMap<String,Object>> result = subDocOps.bulkGetSubDocOperation(target, lookup_docs, lookupInOptions);
                     ops += dg.ws.batchSize*dg.ws.subdocs/100;
                     this.completedOps.addAndGet(lookup_docs.size());
                     this.update_subdoc_failed_mutation_result("lookup", failedMutations, result);
@@ -406,7 +411,7 @@ public class WorkLoadGenerate extends Task{
                 docs = dg.nextSubDocBatch("remove");
                 if (docs.size()>0) {
                     flag = true;
-                    List<HashMap<String,Object>> result = subDocOps.bulkSubDocOperation(this.sdk.connection, docs, mutateInOptions);
+                    List<HashMap<String,Object>> result = subDocOps.bulkSubDocOperation(target, docs, mutateInOptions);
                     ops += dg.ws.batchSize*dg.ws.subdocs/100;
                     this.completedOps.addAndGet(docs.size());
                     this.update_subdoc_failed_mutation_result("remove", failedMutations, result);
@@ -447,7 +452,7 @@ public class WorkLoadGenerate extends Task{
                     switch(optype.getKey()) {
                     case "create":
                         try {
-                            docops.insert(r.id(), r.document(), this.sdk.connection, setOptions);
+                            docops.insert(r.id(), r.document(), target, setOptions);
                             failedMutations.get(optype.getKey()).remove(r);
                         } catch (TimeoutException|ServerOutOfMemoryException e) {
                             System.out.println("Retry Create failed for key: " + r.id());
@@ -460,7 +465,7 @@ public class WorkLoadGenerate extends Task{
                         }
                     case "update":
                         try {
-                            docops.upsert(r.id(), r.document(), this.sdk.connection, upsertOptions);
+                            docops.upsert(r.id(), r.document(), target, upsertOptions);
                             failedMutations.get(optype.getKey()).remove(r);
                         } catch (TimeoutException|ServerOutOfMemoryException e) {
                             System.out.println("Retry update failed for key: " + r.id());
@@ -474,7 +479,7 @@ public class WorkLoadGenerate extends Task{
                         }
                     case "delete":
                         try {
-                            docops.delete(r.id(), this.sdk.connection, removeOptions);
+                            docops.delete(r.id(), target, removeOptions);
                             failedMutations.get(optype.getKey()).remove(r);
                         } catch (TimeoutException|ServerOutOfMemoryException e) {
                             System.out.println("Retry delete failed for key: " + r.id());
@@ -489,26 +494,26 @@ public class WorkLoadGenerate extends Task{
         }
     }
 
+    /**
+     * The collection this worker loads. Pool clients are shared across collections, so
+     * the handle is resolved per worker and kept local; a client built for one specific
+     * collection (the CLI loaders) already knows its own.
+     */
+    private Collection targetCollection() {
+        if (this.sdkClientPool != null) {
+            return this.sdk.collection(this.scope, this.collection);
+        }
+        return this.sdk.collection();
+    }
+
     @Override
     protected void runTask() {
         if (this.sdkClientPool != null) {
-            try {
-                // Pool blocks internally until a client is available (up to its configured timeout).
-                // No busy-poll needed here — blocking in the pool is cheaper and has no retry cap.
-                this.sdk = this.sdkClientPool.get_client_for_bucket(
-                        this.bucket_name, this.scope, this.collection);
-            } catch (InterruptedException e) {
-                logger.error("Interrupted while waiting for SDK client for bucket "
-                        + this.bucket_name, e);
-                Thread.currentThread().interrupt();
-                this.result = false;
-                return;
-            } catch (Exception e) {
-                logger.error("Error acquiring SDK client for bucket "
-                        + this.bucket_name + ": " + e.getMessage(), e);
-            }
+            // One shared client per bucket - never blocks, never runs out.
+            this.sdk = this.sdkClientPool.get_client_for_bucket(this.bucket_name);
             if (this.sdk == null) {
-                logger.error("Failed to acquire SDK client for bucket " + this.bucket_name);
+                logger.error("No SDK client for bucket " + this.bucket_name
+                        + " - create_clients was not called for it");
                 this.result = false;
                 return;
             }
@@ -519,10 +524,6 @@ public class WorkLoadGenerate extends Task{
         catch (Exception e) {
             logger.error("Unhandled exception in task " + this.taskName + ": " + e.getMessage(), e);
             this.result = false;
-        }
-        finally{
-            if (this.sdkClientPool != null && this.sdk != null)
-                this.sdkClientPool.release_client(this.sdk);
         }
     }
 }

--- a/src/main/java/couchbase/sdk/SDKClient.java
+++ b/src/main/java/couchbase/sdk/SDKClient.java
@@ -21,7 +21,10 @@ public class SDKClient {
     private Bucket bucketObj;
     private Cluster cluster;
 
-    public Collection connection;
+    // Resolved once, for the scope/collection this client was constructed with.
+    // Never reassigned after initialiseSDK(): a client handed out to one caller must
+    // never be re-pointed at a different collection by a second caller.
+    private volatile Collection defaultCollection;
 
     public SDKClient(Server master, String bucket, String scope, String collection) {
         super();
@@ -47,7 +50,8 @@ public class SDKClient {
         logger.info("Connection to the cluster");
         this.connectCluster();
         this.connectBucket(bucket);
-        this.selectCollection(scope, collection);
+        this.defaultCollection = this.bucketObj.scope(this.scope)
+                                               .collection(this.collection);
     }
 
     public void connectCluster(){
@@ -76,9 +80,23 @@ public class SDKClient {
         this.bucketObj = this.cluster.bucket(bucket);
     }
 
-    public void selectCollection(String scope, String collection) {
-        this.connection = this.bucketObj.scope(scope).collection(collection);
-        this.scope = scope;
-        this.collection = collection;
+    /**
+     * Resolve a collection handle for this client's bucket.
+     *
+     * Deliberately a pure function of its arguments: the caller keeps the handle in a
+     * local, so a client shared by many concurrent workers has no per-collection state
+     * for one worker to overwrite while another is mid-batch. Cluster, Bucket and
+     * Collection are all thread-safe and meant to be shared.
+     */
+    public Collection collection(String scope, String collection) {
+        return this.bucketObj.scope(scope).collection(collection);
+    }
+
+    /**
+     * The collection this client was constructed for. Used by the CLI loaders, which
+     * build one client per run rather than going through SDKClientPool.
+     */
+    public Collection collection() {
+        return this.defaultCollection;
     }
 }

--- a/src/main/java/couchbase/sdk/SDKClientPool.java
+++ b/src/main/java/couchbase/sdk/SDKClientPool.java
@@ -1,22 +1,38 @@
 package couchbase.sdk;
 
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
 
+/**
+ * One SDK client per bucket, shared by every worker loading that bucket.
+ *
+ * There used to be a queue of idle clients per bucket plus a cache keyed by
+ * bucket:scope:collection, because a client carried its target collection in a mutable
+ * field and therefore could only serve one collection at a time. That design had two
+ * defects that no amount of locking around the cache would remove:
+ *
+ *  - acquire was a check-then-act (cache lookup, then refcount increment). A release
+ *    landing in that window dropped the refcount to zero, returned the client to the
+ *    idle queue, and let a third thread re-point it at a different collection - while
+ *    the first thread was still using it. Its documents then went to the wrong
+ *    collection, and the failures were reported against the collection it thought it
+ *    was writing to.
+ *  - two concurrent misses on the same key each took a client and the second cache
+ *    entry overwrote the first, so one client was never returned to the pool. With a
+ *    finite pool, repeated leaks eventually wedged every worker in take().
+ *
+ * SDKClient no longer holds collection state (see SDKClient.collection(scope, coll)),
+ * so a client is just a bucket handle. Cluster/Bucket/Collection are thread-safe, so
+ * one handle serves any number of concurrent workers on any number of collections.
+ * There is nothing left to check, to count, to hand out or to give back.
+ */
 public class SDKClientPool {
     static Logger logger = LogManager.getLogger(SDKClientPool.class);
-    
-    // Thread-safe client collection cache
-    private ConcurrentHashMap<String, ClientInfo> clientCache = new ConcurrentHashMap<>();
 
-    // Thread-safe client pools by bucket
-    private ConcurrentHashMap<String, LinkedBlockingQueue<SDKClient>> idleClients = new ConcurrentHashMap<>();
-    private ConcurrentHashMap<String, LinkedBlockingQueue<SDKClient>> busyClients = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, SDKClient> clients = new ConcurrentHashMap<>();
 
     public SDKClientPool() {
         super();
@@ -24,144 +40,39 @@ public class SDKClientPool {
 
     public void shutdown() {
         logger.debug("Closing clients from SDKClientPool and shutting down shared Cluster instances");
-        
-        // Process all buckets
-        for (String bucketName : idleClients.keySet()) {
-            LinkedBlockingQueue<SDKClient> idle = idleClients.get(bucketName);
-            LinkedBlockingQueue<SDKClient> busy = busyClients.get(bucketName);
-            
-            if (idle != null) {
-                for (SDKClient client : idle) {
-                    client.disconnectCluster();
-                }
-            }
-            if (busy != null) {
-                for (SDKClient client : busy) {
-                    client.disconnectCluster();
-                }
-            }
+        for (SDKClient client : clients.values()) {
+            client.disconnectCluster();
         }
-        
-        // Clear all data structures
-        clientCache.clear();
-        idleClients.clear();
-        busyClients.clear();
-        
-        // Shutdown shared Cluster manager
+        clients.clear();
         SharedClusterManager.shutdownAll();
     }
 
     public void force_close_clients_for_bucket(String bucket_name) {
-        LinkedBlockingQueue<SDKClient> idle = idleClients.get(bucket_name);
-        LinkedBlockingQueue<SDKClient> busy = busyClients.get(bucket_name);
-        
-        if (idle != null) {
-            for (SDKClient client : idle) {
-                client.disconnectCluster();
-            }
-            idleClients.remove(bucket_name);
-        }
-        
-        if (busy != null) {
-            for (SDKClient client : busy) {
-                client.disconnectCluster();
-            }
-            busyClients.remove(bucket_name);
+        SDKClient client = clients.remove(bucket_name);
+        if (client != null) {
+            client.disconnectCluster();
         }
     }
 
+    /**
+     * req_clients is accepted for wire compatibility with existing callers but is no
+     * longer meaningful: a single shared handle per bucket serves every worker, so
+     * there is no pool to size and no worker ever blocks waiting for a client.
+     */
     public void create_clients(String bucket_name, Server server, int req_clients) throws Exception {
-        // Initialize thread-safe client pools for this bucket if not already present
-        idleClients.computeIfAbsent(bucket_name, k -> new LinkedBlockingQueue<>());
-        busyClients.computeIfAbsent(bucket_name, k -> new LinkedBlockingQueue<>());
-        
-        LinkedBlockingQueue<SDKClient> idlePool = idleClients.get(bucket_name);
-
-        for (int i = 0; i < req_clients; i++) {
-            SDKClient client = new SDKClient(server, bucket_name);
-            client.initialiseSDK();
-            idlePool.add(client);
+        if (clients.containsKey(bucket_name)) {
+            return;
         }
-    }
-
-    public SDKClient get_client_for_bucket(String bucket_name, String scope, String collection)
-            throws InterruptedException {
-        String cache_key = bucket_name + ":" + scope + ":" + collection;
-
-        // Check if client is already cached for this collection
-        ClientInfo existing = clientCache.get(cache_key);
+        SDKClient client = new SDKClient(server, bucket_name);
+        client.initialiseSDK();
+        SDKClient existing = clients.putIfAbsent(bucket_name, client);
         if (existing != null) {
-            existing.counter.incrementAndGet();
-            return existing.client;
-        }
-
-        // Get idle client pool for this bucket
-        LinkedBlockingQueue<SDKClient> idlePool = idleClients.get(bucket_name);
-        if (idlePool == null) {
-            return null;
-        }
-
-        // Block until a client becomes available.
-        // With many threads sharing a finite pool, spinning with a fixed retry cap
-        // causes spurious failures on long-running loads — blocking indefinitely here
-        // is cheaper and correct. A task holds no client while waiting, so clients are
-        // only ever held by actively-progressing tasks that will eventually release them.
-        SDKClient client = idlePool.take();
-
-        // Configure client for this collection
-        client.selectCollection(scope, collection);
-
-        // Add to busy pool atomically
-        busyClients.computeIfAbsent(bucket_name, k -> new LinkedBlockingQueue<>()).add(client);
-
-        // Cache client reference with thread-safe counter
-        clientCache.put(cache_key, new ClientInfo(client, new AtomicInteger(1)));
-
-        return client;
-    }
-
-    public void release_client(SDKClient client) {
-        if (client == null || client.bucket == null) {
-            return;
-        }
-
-        String bucket_key = client.bucket;
-        String cache_key = bucket_key + ":" + client.scope + ":" + client.collection;
-
-        // Get cached client info
-        ClientInfo info = clientCache.get(cache_key);
-        if (info == null) {
-            return;
-        }
-
-        // Decrement counter atomically
-        int newCount = info.counter.decrementAndGet();
-
-        if (newCount == 0) {
-            // Remove from cache atomically
-            clientCache.remove(cache_key);
-            
-            // Remove from busy pool and add to idle pool atomically
-            LinkedBlockingQueue<SDKClient> busyPool = busyClients.get(bucket_key);
-            LinkedBlockingQueue<SDKClient> idlePool = idleClients.get(bucket_key);
-            
-            if (busyPool != null) {
-                busyPool.remove(client);
-            }
-            if (idlePool != null) {
-                idlePool.add(client);
-            }
+            // Lost a concurrent create for the same bucket - drop ours.
+            client.disconnectCluster();
         }
     }
-    
-    // Helper class for cached client info with thread-safe counter
-    private static class ClientInfo {
-        SDKClient client;
-        AtomicInteger counter;
-        
-        ClientInfo(SDKClient client, AtomicInteger counter) {
-            this.client = client;
-            this.counter = counter;
-        }
+
+    public SDKClient get_client_for_bucket(String bucket_name) {
+        return clients.get(bucket_name);
     }
 }

--- a/src/main/java/utils/taskmanager/Task.java
+++ b/src/main/java/utils/taskmanager/Task.java
@@ -19,6 +19,10 @@ public abstract class Task implements Runnable{
     // True when this task was cancelled before it ever ran because the work it
     // would have done was already finished by a sibling. Not a failure.
     public volatile boolean skipped = false;
+    // True once a pool thread has actually begun executing this task. A task that has
+    // never been dequeued is waiting for a thread, which is a queueing question, not a
+    // hang - callers polling for progress must not time it out as a stall.
+    public volatile boolean started = false;
     // Set only for workers that share one document generator with their siblings.
     public TaskGroup group = null;
     // Won by exactly one of: the thread about to execute this task, or skipTask()
@@ -77,6 +81,7 @@ public abstract class Task implements Runnable{
             this.result = true;
             return;
         }
+        this.started = true;
         this.runTask();
     }
 


### PR DESCRIPTION
- SDKClientPool.get_client_for_bucket did an unsynchronized check-then-act: a release landing between the cache lookup and the refcount increment returned the client to the idle queue, letting a third thread selectCollection() it while the first was mid-batch
- a worker's documents then went to another collection, and the DocumentExistsExceptions were reported against the collection it believed it was writing to
- two concurrent misses on one key also leaked a client permanently, which drains a finite pool and wedges every worker in take()
- SDKClient no longer stores the target collection; collection(scope, coll) resolves it and WorkLoadGenerate keeps it in a local
- with no per-collection state a single handle per bucket serves every worker, so the idle/busy queues, the cache, the refcounts and the blocking acquire all go away
- Task.started + has_started in get_task_progress, so a caller can tell a queued task from a running one and not time it out as a stall